### PR TITLE
Export the showSnackbar function

### DIFF
--- a/src/snackbar/snackbar-container.svelte
+++ b/src/snackbar/snackbar-container.svelte
@@ -14,7 +14,7 @@
     registeredSnackbars = registeredSnackbars;
   }
 
-  function showSnackbar(options) {
+  export function showSnackbar(options) {
     const {
       component = Snackbar,
       props = {},


### PR DESCRIPTION
This is to be able to use this function in the same component where the `SnackbarContainer` is defined (so context and the slot props are not available). One just needs to bind:this to some variable and call the `showSnackbar` method on that variable.