### PR TITLE
Add postinstall script to move files from src to .

### DIFF
--- a/move.js
+++ b/move.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+
+const files = fs.readdirSync('./src');
+
+for (const file of files) {
+  fs.renameSync(`./src/${file}`, `./${file}`);
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "rollup -c",
     "prepublishOnly": "npm run build",
     "dev": "rollup -c -w",
-    "start": "sirv demo/public --host 0.0.0.0"
+    "start": "sirv demo/public --host 0.0.0.0",
+    "postinstall": "node move.js"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^6.0.0",


### PR DESCRIPTION
Instead of having to use `'attractions/src/*'` when importing something specific, everything in the `src` folder will now be moved up one level to the current (installation) directory.