### PR TITLE
Refactor the Autocomplete to ignore the return of the generator

### DIFF
--- a/attractions/autocomplete/autocomplete-field.svelte
+++ b/attractions/autocomplete/autocomplete-field.svelte
@@ -41,9 +41,13 @@
     }
   }
 
-  function filterOutSelected(generatorValue) {
-    moreOptions = !generatorValue.done;
-    return generatorValue.value.filter(
+  function filterOutSelected(generatorState) {
+    moreOptions = !generatorState.done;
+    if (generatorState.value == null) {
+      return [];
+    }
+
+    return generatorState.value.filter(
       option => selection.find(thisOption => thisOption === option) == null,
     );
   }

--- a/attractions/autocomplete/autocomplete.scss
+++ b/attractions/autocomplete/autocomplete.scss
@@ -43,7 +43,7 @@
     display: flex;
     align-items: center;
     padding-left: .7em;
-    margin-right: .4em;
+    margin: .2em .4em .2em 0;
     font-size: .95em;
 
     :global(.btn) {

--- a/demo/get-autocomplete-options.js
+++ b/demo/get-autocomplete-options.js
@@ -43,5 +43,5 @@ export default async function *getOptions(query) {
   await sleep(150);
   yield people2;
   await sleep(150);
-  return people3;
+  yield people3;
 }


### PR DESCRIPTION
Apparently, returning a value from a generator not only looks ugly, but also causes issues with stuff like generator delegation. In Innopoints I had an async generator that was returning the last value, as opposed to yielding it and then returning `undefined`. And apparently in some cases the returned value of generators is ignored, for instance, in `for ... of` loops and generator delegation. This will allow returning `undefined` (and this should be the best practice for this function)