### PR TITLE
Allow omitting the callback in the snackbar action

### DIFF
--- a/attractions/snackbar/snackbar.svelte
+++ b/attractions/snackbar/snackbar.svelte
@@ -27,7 +27,10 @@
     <Button
       class={buttonClass}
       on:click={() => {
-        action.callback();
+        if (typeof action.callback === 'function') {
+          action.callback();
+        }
+
         if (closeOnAction) {
           closeCallback();
         }


### PR DESCRIPTION
In some cases one only wants the snackbar action to close it (in order to force some action, as in `undo`, for example, would _actually_ do the action after the snackbar expires).