### PR TITLE
Allow disabling the clickaway behaviour of the modal overlay

### DIFF
--- a/attractions/modal/modal.svelte
+++ b/attractions/modal/modal.svelte
@@ -5,6 +5,7 @@
   let _class = null;
   export { _class as class };
   export let open = false;
+  export let clickaway = true;
   $: dispatch('change', { value: open });
 
   function close() {
@@ -14,12 +15,18 @@
   const dispatch = createEventDispatcher();
 </script>
 
-<div
-  class:open
-  on:click|self={close}
-  class={classes('modal-overlay', _class)}
->
-  <slot closeCallback={close} />
-</div>
+{#if clickaway}
+  <div
+    class:open
+    on:click|self={close}
+    class={classes('modal-overlay', _class)}
+  >
+    <slot closeCallback={close} />
+  </div>
+{:else}
+  <div class:open class={classes('modal-overlay', _class)}>
+    <slot closeCallback={close} />
+  </div>
+{/if}
 
 <style src="./modal-overlay.scss"></style>


### PR DESCRIPTION
I deliberately opted for a certain amount of code duplication to prevent from messing around with the code structure + remove an event listener when it's not used