### PR TITLE
Make the tiles on the home page capable of navigation

### DIFF
--- a/docs/src/components/home/info-tile.svelte
+++ b/docs/src/components/home/info-tile.svelte
@@ -1,12 +1,14 @@
 <script>
+  import { goto } from '@sapper/app';
   import { Card } from 'attractions';
 
   export let icon;
   export let title;
   export let subtitle;
+  export let href;
 </script>
 
-<div class="info-tile">
+<div class="info-tile" on:click={() => goto(href)}>
   <Card>
     <div class="icon">
       <svelte:component this={icon} size="24" />

--- a/docs/src/containers/home/info-tiles.svelte
+++ b/docs/src/containers/home/info-tiles.svelte
@@ -12,16 +12,19 @@
     icon={GridIcon}
     title="{totalComponents} component{s(totalComponents)}"
     subtitle="and more to come!"
+    href="./docs/components/button"
   />
   <InfoTile
     icon={Edit2Icon}
     title="Stylable with Sass"
     subtitle="customize colors, fonts, shadows!"
+    href="./docs/installation"
   />
   <InfoTile
     icon={FeatherIcon}
     title="How to compute bundle size?"
     subtitle="please help me!"
+    href="https://bundlephobia.com/result?p=attractions"
   />
 </div>
 

--- a/docs/static/css/components/home/info-tile.scss
+++ b/docs/static/css/components/home/info-tile.scss
@@ -2,12 +2,18 @@
 
 .info-tile {
   margin-bottom: 1em;
+  cursor: pointer;
 
   :global .card {
     display: grid;
     grid-template-columns: auto 1fr;
     grid-template-rows: auto auto;
     column-gap: 1em;
+    transition: 150ms box-shadow;
+
+    &:hover {
+      box-shadow: $shadow-raised;
+    }
   }
 
   .icon {
@@ -16,6 +22,7 @@
     background: $main;
     color: white;
     grid-row: span 2;
+    align-self: center;
 
     :global svg {
       display: block;


### PR DESCRIPTION
The other day I was told (and witnessed how someone kept pressing the tiles) that the tiles look like something you should click, so they completely overlooked the buttons (through the mobile version, anyway).

So I figured, why not. The links for the first two tiles are kind of best-fit, I think it's worth having a separate page listing all the components in the future, which can be an optimal destination for the first tile, and we should also have a separate list of all SCSS variables, where the second tile will be linking. In the meantime,