### PR TITLE
Docs/hotfix/styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.1.1] - 2020-09-01
 
 Just minor documentation fixes.
 
@@ -18,6 +18,7 @@ Just minor documentation fixes.
 
 ### Fixed
 - Mobile navigation in documentation ("Components" tab dropdown now works as expected).
+- Styles now load properly when navigating directly to a page in the docs (without passing through the main page first)
 
 
 ## [2.1.0] - 2020-08-21
@@ -27,4 +28,5 @@ Previous, undocumented, releases can be found in [the releases section](https://
 
 
 [Unreleased]: https://github.com/illright/attractions/compare/v2.1.0...HEAD
+[2.1.1]: https://github.com/illright/attractions/releases/tag/2.1.1
 [2.1.0]: https://github.com/illright/attractions/releases/tag/2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
----
-name: Changelog
----
-
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/attractions/package.json
+++ b/attractions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attractions",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A UI kit for Svelte",
   "license": "MIT",
   "svelte": "index.js",

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log
 /cypress/screenshots/
 /__sapper__/
 .env
+.svx

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-replace": "^2.2.0",
     "attractions": "^2.0.3-alpha",
-    "mdsvex": "^0.8.6",
+    "mdsvex": "^0.8.7",
     "node-sass": "^4.14.1",
     "postcss": "^7.0.32",
     "prism-svelte": "^0.4.6",

--- a/docs/rollup.config.js
+++ b/docs/rollup.config.js
@@ -36,7 +36,9 @@ const preprocess = [
     scss: { includePaths: ['./static/css'] },
   }),
   mdsvex({
-    layout: './src/mdsvex/layout.svelte',
+    layout: {
+      docs: './src/mdsvex/layout.svelte',
+    },
     smartypants: {
       quotes: false,
       ellipses: true,

--- a/docs/rollup.config.js
+++ b/docs/rollup.config.js
@@ -38,6 +38,7 @@ const preprocess = [
   mdsvex({
     layout: {
       docs: './src/mdsvex/layout.svelte',
+      _: './src/mdsvex/layout-no-head.svelte',
     },
     smartypants: {
       quotes: false,

--- a/docs/src/mdsvex/layout-no-head.svelte
+++ b/docs/src/mdsvex/layout-no-head.svelte
@@ -1,0 +1,29 @@
+<script context="module">
+  import Heading1 from 'src/mdsvex/h1.svelte';
+  import Heading2 from 'src/mdsvex/h2.svelte';
+  import Heading3 from 'src/mdsvex/h3.svelte';
+  import UnorderedList from 'src/mdsvex/ul.svelte';
+  import ListItem from 'src/mdsvex/li.svelte';
+  import Table from 'src/mdsvex/table.svelte';
+  import TableHead from 'src/mdsvex/th.svelte';
+  import TableRow from 'src/mdsvex/tr.svelte';
+  import TableData from 'src/mdsvex/td.svelte';
+  import Mark from 'src/mdsvex/mark.svelte';
+  import Paragraph from 'src/mdsvex/p.svelte';
+
+  export {
+    Heading1 as h1,
+    Heading2 as h2,
+    Heading3 as h3,
+    UnorderedList as ul,
+    ListItem as li,
+    Table as table,
+    TableHead as th,
+    TableRow as tr,
+    TableData as td,
+    Mark as mark,
+    Paragraph as p,
+  };
+</script>
+
+<slot />

--- a/docs/static/css/_attractions-theme.scss
+++ b/docs/static/css/_attractions-theme.scss
@@ -15,3 +15,7 @@ $shadow-raised:
   0 3px 5px 0    transparentize(black, .86),
   0 1px 10px 0   transparentize(black, .88);
 /* stylelint-enable scss/dollar-variable-colon-space-after */
+
+:global {
+  @import "global.scss";
+}

--- a/docs/static/css/global.scss
+++ b/docs/static/css/global.scss
@@ -1,5 +1,3 @@
-@import "_attractions-theme.scss";
-
 * {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }

--- a/docs/static/css/routes/index.scss
+++ b/docs/static/css/routes/index.scss
@@ -1,9 +1,5 @@
 @import "_attractions-theme.scss";
 
-:global {
-  @import "global.scss";
-}
-
 $mobile-top-padding: 2.4em;
 
 main {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3174,10 +3174,10 @@ mdast-util-compact@^2.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
-mdsvex@^0.8.6:
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/mdsvex/-/mdsvex-0.8.6.tgz#fe33c58de1f7b6b8539032118f3c3437e7cbf195"
-  integrity sha512-VxXv5jLBB3+QqhPbW/shVDzFa+jfI1P+stJxj6yKLIFS+Xuu2ebwqT1Q65v31MQtGCt31hLZZo/LyWzX00Xi0Q==
+mdsvex@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/mdsvex/-/mdsvex-0.8.7.tgz#4b85de513826ec316677ee6d25eeaa1595edbe66"
+  integrity sha512-ugrKnITfKwvrHD2lSp/W28Fm2wCGrJbQzxyAuHwZSSA34DM1NzoEgUWqB7hLKUCmR8cAI/d88MHP/JxCMjESog==
   dependencies:
     "@types/unist" "^2.0.3"
     prismjs "^1.17.1"


### PR DESCRIPTION
When navigating to a docs page directly, the global styles were not loaded because they were only included in the main page.
This should fix it