### PR TITLE
Update the dropdown event interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.1.1] - 2020-09-01
+## [2.1.1] - 2020-09-02
 
-Just minor documentation fixes.
+Minor documentation and bug fixes.
 
 ### Added
 - [`<Tab>`](https://github.com/illright/attractions/blob/master/attractions/tab/tab.svelte)s
@@ -14,7 +14,8 @@ Just minor documentation fixes.
 
 ### Fixed
 - Mobile navigation in documentation ("Components" tab dropdown now works as expected).
-- Styles now load properly when navigating directly to a page in the docs (without passing through the main page first)
+- Styles now load properly when navigating directly to a page in the docs (without passing through the main page first).
+- The `DatePicker` now loses focus properly.
 
 
 ## [2.1.0] - 2020-08-21

--- a/attractions/date-picker/date-picker.svelte
+++ b/attractions/date-picker/date-picker.svelte
@@ -56,7 +56,7 @@
   }
 
   function clearFocus({ detail: open }) {
-    if (!open) {
+    if (!open.value) {
       startFocus = false;
       endFocus = false;
     }


### PR DESCRIPTION
Previously the DatePicker was built with a `bool` event detail, which was changed to `{ value }` at some point. This will fix the focusing bug.

Closes #138 