### PR TITLE
Change the trigger to pull_request_target

### DIFF
--- a/.github/workflows/pr_demo.yml
+++ b/.github/workflows/pr_demo.yml
@@ -38,7 +38,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Extract PR number
-      run: echo "::set-env name=PR_NUMBER::$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')"
+      run: echo "PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')" >> $GITHUB_ENV
 
     - uses: actions/setup-node@v1
     - name: Install and Build

--- a/.github/workflows/pr_demo.yml
+++ b/.github/workflows/pr_demo.yml
@@ -1,7 +1,7 @@
 name: Deploy PR docs to Pages
 
 on:
-  pull_request
+  pull_request_target
 
 jobs:
   build:


### PR DESCRIPTION
The docs say it should run the CI based on our code, not the fork's which will make the token read-write and allow publishing to GH Pages