### PR TITLE
Remove svelte:options tag

### DIFF
--- a/attractions/accordion/accordion-section.svelte
+++ b/attractions/accordion/accordion-section.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-accordion-section" />
-
 <script>
   import Button from '../button/button.svelte';
   import { createEventDispatcher } from 'svelte';

--- a/attractions/accordion/accordion.svelte
+++ b/attractions/accordion/accordion.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-accordion" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/autocomplete/autocomplete-field.svelte
+++ b/attractions/autocomplete/autocomplete-field.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-autocomplete-field" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import DropdownShell from '../dropdown/dropdown-shell.svelte';

--- a/attractions/autocomplete/autocomplete-option.svelte
+++ b/attractions/autocomplete/autocomplete-option.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-autocomplete-option" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
 

--- a/attractions/autocomplete/autocomplete.svelte
+++ b/attractions/autocomplete/autocomplete.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-autocomplete" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import Button from '../button/button.svelte';

--- a/attractions/autocomplete/more-horizontal.svelte
+++ b/attractions/autocomplete/more-horizontal.svelte
@@ -1,6 +1,4 @@
 <!-- More-horizontal icon from the Feather Icons pack: https://feathericons.com/ -->
-<svelte:options tag={null} />
-
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width="24"

--- a/attractions/badge/badge.svelte
+++ b/attractions/badge/badge.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-badge" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/button/button.svelte
+++ b/attractions/button/button.svelte
@@ -1,7 +1,3 @@
-<!-- TODO: Decide whether to write out all tag names or leave them as null
-        for the users to set manually -->
-<svelte:options tag="a-button" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import ripple from '../utils/ripple.js';

--- a/attractions/button/button.svelte
+++ b/attractions/button/button.svelte
@@ -1,3 +1,5 @@
+<!-- TODO: Decide whether to write out all tag names or leave them as null
+        for the users to set manually -->
 <svelte:options tag="a-button" />
 
 <script>

--- a/attractions/card/card.svelte
+++ b/attractions/card/card.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-card" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/checkbox/checkbox-group.svelte
+++ b/attractions/checkbox/checkbox-group.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-checkbox-group" />
-
 <script>
   import classes from '../utils/classes.js';
   import getColorPickerStyles from '../utils/color-picker-styles.js';

--- a/attractions/checkbox/checkbox.svelte
+++ b/attractions/checkbox/checkbox.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-checkbox" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/chip/checkbox-chip-group.svelte
+++ b/attractions/chip/checkbox-chip-group.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-checkbox-chip-group" />
-
 <script>
   import s from '../utils/plural-s.js';
   import classes from '../utils/classes.js';

--- a/attractions/chip/checkbox-chip.svelte
+++ b/attractions/chip/checkbox-chip.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-checkbox-chip" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/chip/chip.svelte
+++ b/attractions/chip/chip.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-chip" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/chip/radio-chip-group.svelte
+++ b/attractions/chip/radio-chip-group.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-radio-chip-group" />
-
 <script>
   import classes from '../utils/classes.js';
   import RadioChip from './radio-chip.svelte';

--- a/attractions/chip/radio-chip.svelte
+++ b/attractions/chip/radio-chip.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-radio-chip" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/date-picker/calendar.svelte
+++ b/attractions/date-picker/calendar.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-calendar" />
-
 <script>
   import Button from '../button/button.svelte';
   import { createEventDispatcher } from 'svelte';

--- a/attractions/date-picker/chevron-left.svelte
+++ b/attractions/date-picker/chevron-left.svelte
@@ -1,6 +1,4 @@
 <!-- Chevron-left icon from the Feather Icons pack: https://feathericons.com/ -->
-<svelte:options tag={null} />
-
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width="24"

--- a/attractions/date-picker/chevron-right.svelte
+++ b/attractions/date-picker/chevron-right.svelte
@@ -1,6 +1,4 @@
 <!-- Chevron-right icon from the Feather Icons pack: https://feathericons.com/ -->
-<svelte:options tag={null} />
-
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width="24"

--- a/attractions/date-picker/date-picker.svelte
+++ b/attractions/date-picker/date-picker.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-date-picker" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/dialog/dialog.svelte
+++ b/attractions/dialog/dialog.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-dialog" />
-
 <script>
   import Button from '../button/button.svelte';
   import X from './x.svelte';

--- a/attractions/dialog/x.svelte
+++ b/attractions/dialog/x.svelte
@@ -1,6 +1,4 @@
 <!-- X icon from the Feather Icons pack: https://feathericons.com/ -->
-<svelte:options tag={null} />
-
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width="24"

--- a/attractions/divider/divider.svelte
+++ b/attractions/divider/divider.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-divider" />
-
 <script>
   export let text = null;
 </script>

--- a/attractions/dot/dot.svelte
+++ b/attractions/dot/dot.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-dot" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/dropdown/dropdown-shell.svelte
+++ b/attractions/dropdown/dropdown-shell.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-dropdown-shell" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/dropdown/dropdown.svelte
+++ b/attractions/dropdown/dropdown.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-dropdown" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/file-input/file-dropzone.svelte
+++ b/attractions/file-input/file-dropzone.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-file-dropzone" />
-
 <script>
   import Paperclip from './paperclip.svelte';
   import Plus from './plus.svelte';

--- a/attractions/file-input/file-input.svelte
+++ b/attractions/file-input/file-input.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-file-input" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import Button from '../button/button.svelte';

--- a/attractions/file-input/file-tile.svelte
+++ b/attractions/file-input/file-tile.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-file-tile" />
-
 <script>
   import Trash2 from './trash-2.svelte';
   import Button from '../button/button.svelte';

--- a/attractions/file-input/paperclip.svelte
+++ b/attractions/file-input/paperclip.svelte
@@ -1,6 +1,4 @@
 <!-- Paperclip icon from the Feather Icons pack: https://feathericons.com/ -->
-<svelte:options tag={null} />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/file-input/plus.svelte
+++ b/attractions/file-input/plus.svelte
@@ -1,6 +1,4 @@
 <!-- Plus icon from the Feather Icons pack: https://feathericons.com/ -->
-<svelte:options tag={null} />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/file-input/trash-2.svelte
+++ b/attractions/file-input/trash-2.svelte
@@ -1,6 +1,4 @@
 <!-- Trash-2 icon from the Feather Icons pack: https://feathericons.com/ -->
-<svelte:options tag={null} />
-
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width="24"

--- a/attractions/form-field/form-field.svelte
+++ b/attractions/form-field/form-field.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-form-field" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/loading/loading.svelte
+++ b/attractions/loading/loading.svelte
@@ -1,6 +1,4 @@
 <!-- Adapted from SpinKit by @tobiasahlin: https://tobiasahlin.com/spinkit/ -->
-<svelte:options tag="a-loading" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/modal/modal.svelte
+++ b/attractions/modal/modal.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-modal" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/package.json
+++ b/attractions/package.json
@@ -24,6 +24,7 @@
     "pkg-versions": "^2.1.0",
     "rollup": "^2.18.2",
     "rollup-plugin-svelte": "^6.1.1",
+    "rollup-plugin-terser": "^7.0.2",
     "svelte": "^3.24.0",
     "svelte-preprocess": "^4.5.2"
   },

--- a/attractions/pagination/pagination.svelte
+++ b/attractions/pagination/pagination.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-pagination" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import Button from '../button/button.svelte';

--- a/attractions/popover/popover-button.svelte
+++ b/attractions/popover/popover-button.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-popover-button" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/popover/popover.svelte
+++ b/attractions/popover/popover.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-popover" />
-
 <script>
   import classes from '../utils/classes.js';
   import PopoverPositions from './popover-positions.js';

--- a/attractions/radio-button/radio-button.svelte
+++ b/attractions/radio-button/radio-button.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-radio-button" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/radio-button/radio-group.svelte
+++ b/attractions/radio-button/radio-group.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-radio-group" />
-
 <script>
   import classes from '../utils/classes.js';
   import getColorPickerStyles from '../utils/color-picker-styles.js';

--- a/attractions/rollup.config.js
+++ b/attractions/rollup.config.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import svelte from 'rollup-plugin-svelte';
+import { terser } from 'rollup-plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import autoPreprocess from 'svelte-preprocess';
 import pkg from './package.json';
@@ -42,6 +43,9 @@ export default [
     plugins: [
       svelte(),
       resolve(),
+      terser({
+        module: true,
+      }),
     ],
   },
   {
@@ -62,6 +66,9 @@ export default [
         ],
       }),
       resolve(),
+      terser({
+        module: true,
+      }),
     ],
   },
 ];

--- a/attractions/rollup.config.js
+++ b/attractions/rollup.config.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import svelte from 'rollup-plugin-svelte';
 import resolve from '@rollup/plugin-node-resolve';
 import autoPreprocess from 'svelte-preprocess';
@@ -7,6 +8,29 @@ const name = pkg.name
   .replace(/^(@\S+\/)?(svelte-)?(\S+)/, '$3')
   .replace(/^\w/, m => m.toUpperCase())
   .replace(/-\w/g, m => m[1].toUpperCase());
+
+function prependTagOption(exceptions = []) {
+  return {
+    markup({ content, filename }) {
+      const name = path.basename(filename, '.svelte');
+      const tagName = exceptions.includes(name) ? '{null}' : `a-${name}`;
+      const optionsTag = `<svelte:options tag="${tagName}" />`;
+      return { code: optionsTag + '\n\n' + content };
+    },
+  };
+}
+
+const icons = [
+  'more-horizontal',
+  'chevron-left',
+  'chevron-right',
+  'x',
+  'paperclip',
+  'plus',
+  'trash-2',
+  'star',
+  'clock',
+];
 
 export default [
   {
@@ -21,7 +45,6 @@ export default [
     ],
   },
   {
-    // This will likely replace the other configuration above
     input: 'index.js',
     output: {
       file: 'dist/bundle.js',
@@ -31,9 +54,12 @@ export default [
     plugins: [
       svelte({
         customElement: true,
-        preprocess: autoPreprocess({
-          scss: { includePaths: ['./'] },
-        }),
+        preprocess: [
+          prependTagOption(icons),
+          autoPreprocess({
+            scss: { includePaths: ['./'] },
+          }),
+        ],
       }),
       resolve(),
     ],

--- a/attractions/snackbar/snackbar-container.svelte
+++ b/attractions/snackbar/snackbar-container.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-snackbar-container" />
-
 <script>
   import { setContext } from 'svelte';
   import Snackbar from './snackbar.svelte';

--- a/attractions/snackbar/snackbar.svelte
+++ b/attractions/snackbar/snackbar.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-snackbar" />
-
 <script>
   import Button from '../button/button.svelte';
   import { fly } from 'svelte/transition';

--- a/attractions/star-rating/star-rating.svelte
+++ b/attractions/star-rating/star-rating.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-star-rating" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import Star from './star.svelte';

--- a/attractions/star-rating/star.svelte
+++ b/attractions/star-rating/star.svelte
@@ -1,6 +1,4 @@
 <!-- Star icon from the Feather Icons pack: https://feathericons.com/ -->
-<svelte:options tag={null} />
-
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width="24"

--- a/attractions/switch/switch.svelte
+++ b/attractions/switch/switch.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-switch" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/tab/tab.svelte
+++ b/attractions/tab/tab.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-tab" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import rippleEffect from '../utils/ripple.js';

--- a/attractions/tab/tabs.svelte
+++ b/attractions/tab/tabs.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-tabs" />
-
 <script>
   import classes from '../utils/classes.js';
   import Tab from './tab.svelte';

--- a/attractions/text-field/text-field.svelte
+++ b/attractions/text-field/text-field.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-text-field" />
-
 <script>
   import { createEventDispatcher, onMount } from 'svelte';
   import eventsAction from '../utils/events.js';

--- a/attractions/time-picker/clock.svelte
+++ b/attractions/time-picker/clock.svelte
@@ -1,6 +1,4 @@
 <!-- Clock icon from the Feather Icons pack: https://feathericons.com/ -->
-<svelte:options tag={null} />
-
 <svg
   xmlns="http://www.w3.org/2000/svg"
   width="24"

--- a/attractions/time-picker/time-picker.svelte
+++ b/attractions/time-picker/time-picker.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-time-picker" />
-
 <script>
   import { createEventDispatcher } from 'svelte';
   import classes from '../utils/classes.js';

--- a/attractions/typography/h1.svelte
+++ b/attractions/typography/h1.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-h1" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/typography/h2.svelte
+++ b/attractions/typography/h2.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-h2" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/typography/h3.svelte
+++ b/attractions/typography/h3.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-h3" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/typography/headline.svelte
+++ b/attractions/typography/headline.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-headline" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/typography/label.svelte
+++ b/attractions/typography/label.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-label" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/attractions/typography/subhead.svelte
+++ b/attractions/typography/subhead.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="a-subhead" />
-
 <script>
   import classes from '../utils/classes.js';
 

--- a/docs/src/routes/docs/custom-elements.svx
+++ b/docs/src/routes/docs/custom-elements.svx
@@ -15,7 +15,7 @@ An example usage is as follows:
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script src="https://unpkg.com/attractions"></script>
+  <script src="https://unpkg.com/attractions/dist/bundle.js"></script>
 </head>
 
 <body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4326,7 +4326,7 @@ rollup-plugin-svelte@^6.1.1:
     rollup-pluginutils "^2.8.2"
     sourcemap-codec "^1.4.8"
 
-rollup-plugin-terser@^7.0.0:
+rollup-plugin-terser@^7.0.0, rollup-plugin-terser@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
   integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==


### PR DESCRIPTION
To prevent warnings from the Svelte compiler when using the uncompiled version of the library, these changes will add the `<svelte:options tag="..." />` via a preprocessor so that it will be done on the fly (automatically using the file name) and only when needed.

Additionally, I added terser to minify the output files.

Resolves #162 