### PR TITLE
Auto-generate an ID if one is not given

### DIFF
--- a/attractions/form-field/form-field.svelte
+++ b/attractions/form-field/form-field.svelte
@@ -10,6 +10,10 @@
   export let help = null;
   export let id = null;
 
+  if (id == null) {
+    id = `form-field-${Math.random().toString().substring(2, 8)}`;
+  }
+
   export let required = false;
   export let optional = false;
   export let errors = [];

--- a/attractions/pagination/pagination.scss
+++ b/attractions/pagination/pagination.scss
@@ -11,7 +11,7 @@
     > .page {
       width: 2.5em;
       height: 2.5em;
-      margin: 0 .2em;
+      margin: 0 0.2em;
       justify-content: center;
       padding: 0;
       flex-shrink: 0;

--- a/attractions/text-field/text-field.svelte
+++ b/attractions/text-field/text-field.svelte
@@ -23,6 +23,9 @@
   if (!outline && label != null) {
     console.error('Labels are only available for outlined text fields');
   }
+  if (id == null) {
+    id = `text-field-${Math.random().toString().substring(2, 8)}`;
+  }
 
   export let value = null;
   export let events = null;


### PR DESCRIPTION
Closes #167
The warning in the console should be harmless, but this will still prevent it. It has the downside of assigning random IDs to elements even when needed, but the upside of linking the `<input>` with its `<label>` even if the user didn't explicitly provide an id (which should add some convenience).