### PR TITLE
Use a download action that supports cross-workflow

### DIFF
--- a/.github/workflows/pr_docs.yml
+++ b/.github/workflows/pr_docs.yml
@@ -13,13 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download the docs artifact
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: pr_lint_build.yml
+          workflow_conclusion: success
           name: docs
 
       - name: Download the PR number artifact
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: pr_lint_build.yml
+          workflow_conclusion: success
           name: pr_number
 
       - name: Add PR number to env


### PR DESCRIPTION
Since the official actions/download-artifact only works within the same workflow
This Action should be able to download the artifact from a different workflow