### PR TITLE
Fix the DatePicker closing when months have different week numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - The Autocomplete component doesn't throw an error when regex characters are written into it ([#184](https://github.com/illright/attractions/issues/184)).
 - The Autocomplete options weren't showing after selecting something when minimal search length was set to 0 ([#183](https://github.com/illright/attractions/issues/183)).
 - The FileTile component is now correctly clipping long filenames ([#125](https://github.com/illright/attractions/issues/125)).
+- The DatePicker was unexpectedly closing when a certain month change would happen.
 
 ## [2.2.4] - 2020-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Fixed
 
 - The pure-JS bundles now contain styles (so that they are at least not useless).
-- The Autocomplete component doesn't throw an error when regex characters are written into it ([#184](https://github.com/illright/attractions/issues/184)).
+- The Autocomplete component now doesn't throw an error when regex characters are written into it ([#184](https://github.com/illright/attractions/issues/184)).
 - The Autocomplete options weren't showing after selecting something when minimal search length was set to 0 ([#183](https://github.com/illright/attractions/issues/183)).
 - The FileTile component is now correctly clipping long filenames ([#125](https://github.com/illright/attractions/issues/125)).
 - The DatePicker was unexpectedly closing when a certain month change would happen.

--- a/attractions/date-picker/calendar.svelte
+++ b/attractions/date-picker/calendar.svelte
@@ -56,7 +56,7 @@
         <Button
           title={(datesEqual(day.value, today) && 'Today') || null}
           on:click={e => {
-            e.stopPropagation();
+            e.detail.nativeEvent.stopPropagation();
             dispatch('day-select', day.value);
           }}
         >


### PR DESCRIPTION
Bug: if you go to November 2020 and click on the grayed out 1st of December, the dropdown will close, though it shouldn't