### PR TITLE
Copy over the slot defaults from AutocompleteField to Autocomplete

### DIFF
--- a/attractions/autocomplete/autocomplete-field.svelte
+++ b/attractions/autocomplete/autocomplete-field.svelte
@@ -57,7 +57,7 @@
     promises = promises;
 
     if (click != null) {
-      click.stopPropagation();
+      click.detail.nativeEvent.stopPropagation();
     }
   }
 

--- a/attractions/autocomplete/autocomplete.scss
+++ b/attractions/autocomplete/autocomplete.scss
@@ -78,6 +78,7 @@
 .more-options {
   margin-left: 0.5em;
   margin-right: 0.5em;
+  list-style: none;
 
   :global svg {
     margin-right: 0.5em;

--- a/attractions/autocomplete/autocomplete.scss
+++ b/attractions/autocomplete/autocomplete.scss
@@ -56,3 +56,30 @@
     }
   }
 }
+
+// Copied from autocomplete-field.scss to enable slot forwarding
+.notice {
+  font-size: 0.9em;
+  margin: 0.5em;
+  font-weight: $thin-font-weight;
+}
+
+.loading-options {
+  display: flex;
+  align-items: center;
+  font-size: 0.95em;
+  margin: 0.5em 1.2em;
+
+  :global .spinner {
+    margin: 0.3em 0.7em 0.3em 0;
+  }
+}
+
+.more-options {
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+
+  :global svg {
+    margin-right: 0.5em;
+  }
+}

--- a/attractions/autocomplete/autocomplete.svelte
+++ b/attractions/autocomplete/autocomplete.svelte
@@ -5,7 +5,11 @@
   import AutocompleteField from './autocomplete-field.svelte';
   import AutocompleteOption from './autocomplete-option.svelte';
   import X from '../dialog/x.svelte';
+  import Loading from '../loading/loading.svelte';
+  import MoreHorizontal from './more-horizontal.svelte';
   import classes from '../utils/classes.js';
+  import s from '../utils/plural-s.js';
+  import callOnSight from '../utils/call-on-sight.js';
 
   let _class = null;
   export { _class as class };
@@ -47,10 +51,40 @@
     {...$$restProps}
     on:change
   >
-    <slot name="too-many-options" slot="too-many-options" />
-    <slot name="not-enough-input" slot="not-enough-input" />
-    <slot name="loading-options" slot="loading-options" />
-    <slot name="more-options" slot="more-options" />
+    <slot name="too-many-options" slot="too-many-options">
+      <div class="notice">
+        Cannot select more than
+        {maxOptions}
+        option{s(maxOptions)}
+      </div>
+    </slot>
+    <slot name="not-enough-input" slot="not-enough-input">
+      <div class="notice">
+        Type
+        {minSearchLength}
+        character{s(minSearchLength)}
+        to search
+      </div>
+    </slot>
+    <slot name="loading-options" slot="loading-options">
+      <li class="loading-options">
+        <Loading />
+        Loading...
+      </li>
+    </slot>
+    <div slot="more-options" let:loadMoreOptions>
+      <slot name="more-options" {loadMoreOptions}>
+        <li
+          class="more-options"
+          use:callOnSight={{ callback: loadMoreOptions }}
+        >
+          <Button on:click={loadMoreOptions}>
+            <MoreHorizontal />
+            load more options
+          </Button>
+        </li>
+      </slot>
+    </div>
   </AutocompleteField>
 </div>
 

--- a/attractions/autocomplete/autocomplete.svelte
+++ b/attractions/autocomplete/autocomplete.svelte
@@ -72,19 +72,16 @@
         Loading...
       </li>
     </slot>
-    <div slot="more-options" let:loadMoreOptions>
+    <li class="more-options" slot="more-options" let:loadMoreOptions>
       <slot name="more-options" {loadMoreOptions}>
-        <li
-          class="more-options"
-          use:callOnSight={{ callback: loadMoreOptions }}
-        >
+        <div use:callOnSight={{ callback: loadMoreOptions }}>
           <Button on:click={loadMoreOptions}>
             <MoreHorizontal />
             load more options
           </Button>
-        </li>
+        </div>
       </slot>
-    </div>
+    </li>
   </AutocompleteField>
 </div>
 


### PR DESCRIPTION
Previously we were forwarding slots from `AutocompleteField` to `Autocomplete` which essentially works by creating a new slot and providing the content of that slot to the old one, effectively never giving it a chance to render its default. This is a little dirty but it works.

You might also notice that one slot had to be wrapped in an extra DOM element, that's because you cannot forward slot props properly (sigh), in other words, something like this is not possible (and wouldn't seem logical either):
```svelte
<slot slot="smth" name="smth" let:prop {prop} />
```