### PR TITLE
Add ability for initial selection of a radio group button

### DIFF
--- a/attractions/radio-button/radio-group.svelte
+++ b/attractions/radio-button/radio-group.svelte
@@ -68,6 +68,7 @@
         selectorStyle={color ? getColorPickerStyles(item.value) : null}
         bind:group={value}
         value={item.value}
+        checked={item.value === value}
         disabled={item.disabled}
         class={classes(color && 'colored', radioClass)}
         on:change


### PR DESCRIPTION
If the `value` parameter of a radio-group is set, and there is an item with that same value, that button is initially checked. This is more in line with expected behavior. This doesn't appear to change anything after the initial selection.