### PR TITLE
Allow passing the `closeCallback` for snackbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 
 ### Added
 
-- **TypeScript support**: We now provide our own type declaration (`.d.ts`) files so that TypeScript users will have a more delightful development experience! Note that other users are not affected since the components are written in plain JS. ([#211](https://github.com/illright/attractions/pull/211))
+- **TypeScript support**: We now provide our own type declaration (`.d.ts`) files so that TypeScript users will have a more delightful development experience! Note that other users are not affected since the components are written in plain JS ([#211](https://github.com/illright/attractions/pull/211)).
+- Allow passing a `closeCallback` for snackbars ([#216](https://github.com/illright/attractions/pull/216)).
 
 ### Fixed
 

--- a/attractions/snackbar/snackbar-container.svelte
+++ b/attractions/snackbar/snackbar-container.svelte
@@ -45,9 +45,13 @@
     const { component = Snackbar, props = {}, duration = 4000 } = options;
 
     const key = { component, props };
+    const originalCloseCallback = props.closeCallback;
     key.props.closeCallback = function close() {
       clearTimeout(key.timeoutID);
       removeSnackbar(key, true);
+      if (typeof originalCloseCallback === 'function') {
+        originalCloseCallback();
+      }
     };
     key.timeoutID = setTimeout(removeSnackbar, duration, key, false);
     registeredSnackbars.add(key);


### PR DESCRIPTION
Not like this is very public API or a commonly used feature, but I figured why not.

Closes #216 