### PR TITLE
Typings improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 dist
 demo/public/build
-types
+*.d.ts
+*.d.ts.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 
 ### Changed
 
-- Improved TypeScript declaration files. They should now work when importing nested modules such as `attractions/utils` or even `attractions/snackbar/snackbar-positions`. They also now specify `null` as a valid value whereever it is accepted. You may (and should) enable `--strictNullChecks` again!
+- Improved TypeScript declaration files. They should now work when importing nested modules such as `attractions/utils` or even `attractions/snackbar/snackbar-positions`. They also now specify `null` as a valid value wherever it is accepted. You may (and should) enable `--strictNullChecks` again!
 
 ## [3.1.0] - 2021-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Improved TypeScript declaration files. They should now work when importing nested modules such as `attractions/utils` or even `attractions/snackbar/snackbar-positions`. They also now specify `null` as a valid value whereever it is accepted. You may (and should) enable `--strictNullChecks` again!
+
 ## [3.1.0] - 2021-01-22
 
 ### Added

--- a/attractions/accordion/accordion-section.svelte
+++ b/attractions/accordion/accordion-section.svelte
@@ -14,7 +14,7 @@
   /**
    * The label text to use on the button that toggles the section.
    * Not used if the handle slot is provided.
-   * @type {string}
+   * @type {string | null}
    */
   export let label = null;
   /**

--- a/attractions/autocomplete/autocomplete-option.svelte
+++ b/attractions/autocomplete/autocomplete-option.svelte
@@ -13,7 +13,7 @@
   export let option;
   /**
    * The substring to seek out and highlight among the name and the details.
-   * @type {string}
+   * @type {string | null}
    */
   export let query = null;
   $: matchRegex = query ? new RegExp(`(${escapeRegExp(query)})`, 'ig') : null;

--- a/attractions/button/button.svelte
+++ b/attractions/button/button.svelte
@@ -68,7 +68,7 @@
   export let disabled = false;
   /**
    * Turns the button into a link (prefetch-enabled for Sapper).
-   * @type {string}
+   * @type {string | null}
    */
   export let href = null;
   /**

--- a/attractions/checkbox/checkbox-group.svelte
+++ b/attractions/checkbox/checkbox-group.svelte
@@ -12,13 +12,13 @@
   export { _class as class };
   /**
    * A class string to add to the `<Checkbox>` components.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let checkboxClass = null;
   /**
    * A class string to assign to the labels' wrapping `<span>`s.
    * If this is not passed, the labels are not wrapped in a `<span>`.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let labelClass = null;
 

--- a/attractions/checkbox/checkbox.svelte
+++ b/attractions/checkbox/checkbox.svelte
@@ -9,18 +9,18 @@
   export { _class as class };
   /**
    * A class string to assign to the `<input>` element.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let inputClass = null;
   /**
    * A class string to add to the selector box element.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let selectorClass = null;
   /**
    * A CSS style string to assign to the selector box element.
    * Can be used to make the checkbox represent a color (in conjunction with the [`getColorPickerStyles`](https://illright.github.io/attractions/docs/utilities) utility).
-   * @type {string}
+   * @type {string | null}
    */
   export let selectorStyle = null;
 
@@ -51,7 +51,7 @@
   export let round = false;
   /**
    * Adds a tooltip to the checkbox.
-   * @type {string}
+   * @type {string | null}
    */
   export let title = null;
 

--- a/attractions/chip/checkbox-chip-group.svelte
+++ b/attractions/chip/checkbox-chip-group.svelte
@@ -11,12 +11,12 @@
   export { _class as class };
   /**
    * A class string to add to the `<CheckboxChip>` components inside.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let checkboxClass = null;
   /**
    * A class string to add to the wrapping `<span>` around the chips' labels. If it's not specified, the `<span>` will not be added.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let labelClass = null;
 

--- a/attractions/chip/checkbox-chip.svelte
+++ b/attractions/chip/checkbox-chip.svelte
@@ -9,12 +9,12 @@
   export { _class as class };
   /**
    * A class string to add to the `<input>` element.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let inputClass = null;
   /**
    * A class string to add to the underlying `<Chip>` component.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let chipClass = null;
 
@@ -40,7 +40,7 @@
   export let disabled = false;
   /**
    * The tooltip to give to a chip.
-   * @type {string}
+   * @type {string | null}
    */
   export let title = null;
 

--- a/attractions/chip/radio-chip-group.svelte
+++ b/attractions/chip/radio-chip-group.svelte
@@ -10,12 +10,12 @@
   export { _class as class };
   /**
    * A class string to add to the `<RadioChip>` components inside.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let radioClass = null;
   /**
    * A class string to add to the wrapping `<span>` around the chips' labels. If it's not specified, the `<span>` will not be added.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let labelClass = null;
 
@@ -27,7 +27,7 @@
   export let items;
   /**
    * The currently selected value of the group.
-   * @type {string}
+   * @type {string | null}
    */
   export let value = null;
   /**

--- a/attractions/chip/radio-chip.svelte
+++ b/attractions/chip/radio-chip.svelte
@@ -10,12 +10,12 @@
   export { _class as class };
   /**
    * A class string to add to the `<input>` element.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let inputClass = null;
   /**
    * A class string to add to the underlying <Chip> component.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let chipClass = null;
 
@@ -36,12 +36,12 @@
   export let disabled = false;
   /**
    * The currently selected value among the radio chips with the same name. Often used with a two-way binding: `bind:group`.
-   * @type {string}
+   * @type {string | null}
    */
   export let group = null;
   /**
    * The tooltip to give to a chip.
-   * @type {string}
+   * @type {string | null}
    */
   export let title = null;
 

--- a/attractions/date-picker/calendar.svelte
+++ b/attractions/date-picker/calendar.svelte
@@ -14,17 +14,17 @@
 
   /**
    * A class string to add to the list of weekdays above the calendar.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let weekdaysClass = null;
   /**
    * A class string to add to the element containing each row of days in the calendar.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let weekClass = null;
   /**
    * A class string to add to each day in the calendar.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let dayClass = null;
 
@@ -54,12 +54,12 @@
   export let year;
   /**
    * If a selection should be displayed, this should be a `Date` object signifying the start of the selection (can be outside the shown days).
-   * @type {Date}
+   * @type {Date | null}
    */
   export let selectionStart = null;
   /**
    * If a selection should be displayed, this should be a `Date` object signifying the end of the selection (can be outside the shown days).
-   * @type {Date}
+   * @type {Date | null}
    */
   export let selectionEnd = null;
 

--- a/attractions/date-picker/date-picker.svelte
+++ b/attractions/date-picker/date-picker.svelte
@@ -24,17 +24,17 @@
   export { _class as class };
   /**
    * A class string to add to the list of weekdays above the calendar.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let weekdaysClass = null;
   /**
    * A class string to add to each element containing a row of days in the calendar.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let weekClass = null;
   /**
    * A class string to add to each day in the calendar.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let dayClass = null;
 
@@ -73,7 +73,7 @@
   export let right = false;
   /**
    * Depending on the value of the range prop, this is either a `Date` object or an object with two fields, `start` and `end`, containing Date objects.
-   * @type {Date | DateRange}
+   * @type {Date | DateRange | null}
    */
   export let value = null;
   /**

--- a/attractions/dialog/dialog.svelte
+++ b/attractions/dialog/dialog.svelte
@@ -18,7 +18,7 @@
   export let danger = false;
   /**
    * Adds a close button to the dialog and calls this function when it is clicked.
-   * @type {(e: CustomEvent<{ nativeEvent: MouseEvent }>) => void | null}
+   * @type {((e: CustomEvent<{ nativeEvent: MouseEvent }>) => void) | null}
    */
   export let closeCallback = null;
   /**

--- a/attractions/dialog/dialog.svelte
+++ b/attractions/dialog/dialog.svelte
@@ -7,7 +7,7 @@
   export { _class as class };
   /**
    * Adds a title to the dialog.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let titleClass = null;
 
@@ -18,12 +18,12 @@
   export let danger = false;
   /**
    * Adds a close button to the dialog and calls this function when it is clicked.
-   * @type {(e: CustomEvent<{ nativeEvent: MouseEvent }>) => void}
+   * @type {(e: CustomEvent<{ nativeEvent: MouseEvent }>) => void | null}
    */
   export let closeCallback = null;
   /**
    * Adds a title to the dialog.
-   * @type {string}
+   * @type {string | null}
    */
   export let title = null;
   /**

--- a/attractions/divider/divider.svelte
+++ b/attractions/divider/divider.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * Adds a text to the middle of the line.
-   * @type {string}
+   * @type {string | null}
    */
   export let text = null;
 </script>

--- a/attractions/file-input/file-dropzone.svelte
+++ b/attractions/file-input/file-dropzone.svelte
@@ -29,13 +29,13 @@
   export let fileComponent = FileTile;
   /**
    * Limits the allowed files to particular types. For guidelines on the value of the attribute, consult the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).
-   * @type {string}
+   * @type {string | null}
    */
   export let accept = null;
   /**
    * A callback to call for each file that passes the `accept` check before it is added to the `files`.
    * If it returns a Promise, they will be started for every file in parallel and awaited together at the end.
-   * @type {(file: File) => void | Promise<void>}
+   * @type {(file: File) => void | Promise<void> | null}
    */
   export let beforeChange = null;
   /**

--- a/attractions/file-input/file-dropzone.svelte
+++ b/attractions/file-input/file-dropzone.svelte
@@ -35,7 +35,7 @@
   /**
    * A callback to call for each file that passes the `accept` check before it is added to the `files`.
    * If it returns a Promise, they will be started for every file in parallel and awaited together at the end.
-   * @type {(file: File) => void | Promise<void> | null}
+   * @type {((file: File) => void | Promise<void>) | null}
    */
   export let beforeChange = null;
   /**

--- a/attractions/file-input/file-input.svelte
+++ b/attractions/file-input/file-input.svelte
@@ -11,7 +11,7 @@
   export { _class as class };
   /**
    * A class string to add to the `<label>` element wrapping the `<input>`.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let labelClass = null;
 
@@ -27,7 +27,7 @@
   export let vertical = false;
   /**
    * The user's selection. If `multiple` is `false`, the value is an actual `File` object, not a one-element `FileList`, as opposed to the native `<input type="file">`.
-   * @type {File | FileList}
+   * @type {File | FileList | null}
    */
   export let value = multiple ? [] : null;
   /**

--- a/attractions/form-field/form-field.svelte
+++ b/attractions/form-field/form-field.svelte
@@ -5,29 +5,29 @@
   export { _class as class };
   /**
    * A class string to add to the `<label>` containing the form field name.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let nameClass = null;
   /**
    * A class string to add to the help text of the form field.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let helpClass = null;
 
   /**
    * The name of the form field. Displayed prominently next to the actual field.
-   * @type {string}
+   * @type {string | null}
    */
   export let name = null;
   /**
    * The subtitle text under the name providing extra guidance.
-   * @type {string}
+   * @type {string | null}
    */
   export let help = null;
   /**
    * The ID to add the the `for` attribute of the `<label>` element containing the `name`.
    * Useful if you pass an ID to the actual field inside and want to connect it with the label.
-   * @type {string}
+   * @type {string | null}
    */
   export let id = null;
 

--- a/attractions/importer.js
+++ b/attractions/importer.js
@@ -1,6 +1,6 @@
 /**
- * Creates a custom Sass importer for painless configurations
- * @param {{themeFile?: string; nodeModulesPath?: string}} [options]
+ * Creates a custom Sass importer for painless configurations.
+ * @param {{ themeFile?: string; nodeModulesPath?: string }} [options]
  * @returns {(url: string, prev?: string) => ({ file: string } | null)}
  */
 module.exports = function makeAttractionsImporter(options = {}) {

--- a/attractions/importer.js
+++ b/attractions/importer.js
@@ -1,3 +1,8 @@
+/**
+ * Creates a custom Sass importer for painless configurations
+ * @param {{themeFile?: string; nodeModulesPath?: string}} [options]
+ * @returns {(url: string, prev?: string) => ({ file: string } | null)}
+ */
 module.exports = function makeAttractionsImporter(options = {}) {
   const { themeFile, nodeModulesPath = 'node_modules' } = options;
 

--- a/attractions/package.json
+++ b/attractions/package.json
@@ -14,7 +14,7 @@
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "unpkg": "dist/custom-elements.js",
-  "types": "./types/index.d.ts",
+  "types": "./index.d.ts",
   "sideEffects": [
     "./dist/custom-elements.js"
   ],

--- a/attractions/popover/popover.svelte
+++ b/attractions/popover/popover.svelte
@@ -6,7 +6,7 @@
   export { _class as class };
   /**
    * A class string to add to the popover.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let popoverClass = null;
 

--- a/attractions/popover/popover.svelte
+++ b/attractions/popover/popover.svelte
@@ -12,7 +12,7 @@
 
   /**
    * The position of the popover content relative to the triggering handle.
-   * @type {typeof import("../../popover").PopoverPositions}
+   * @type {typeof import('./popover-positions').default}
    */
   export let position = PopoverPositions.TOP;
 </script>

--- a/attractions/radio-button/radio-button.svelte
+++ b/attractions/radio-button/radio-button.svelte
@@ -9,18 +9,18 @@
   export { _class as class };
   /**
    * A class string to assign to the `<input>` element.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let inputClass = null;
   /**
    * A class string to add to the selector circle.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let selectorClass = null;
   /**
    * A CSS style string to assign to the selector circle.
    * Can be used to make the radio button represent a color (in conjunction with the `getColorPickerStyles` utility).
-   * @type {string}
+   * @type {string | null}
    */
   export let selectorStyle = null;
 
@@ -37,7 +37,7 @@
   /**
    * The value of the currently selected radio button in the `name` group.
    * Similar to Svelte's `bind:group` binding on native radio buttons.
-   * @type {string}
+   * @type {string | null}
    */
   export let group = null;
   /**
@@ -47,7 +47,7 @@
   export let slotLeft = false;
   /**
    * Adds a tooltip to the radio button.
-   * @type {string}
+   * @type {string | null}
    */
   export let title = null;
 

--- a/attractions/radio-button/radio-group.svelte
+++ b/attractions/radio-button/radio-group.svelte
@@ -11,13 +11,13 @@
   export { _class as class };
   /**
    * A class string to add to the `<RadioButton>` components.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let radioClass = null;
   /**
    * A class string to assign to the labels' wrapping `<span>`s.
    * If this is not passed, the labels are not wrapped in a `<span>`.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let labelClass = null;
 
@@ -34,7 +34,7 @@
   export let items;
   /**
    * The currently selected value of the group.
-   * @type {string}
+   * @type {string | null}
    */
   export let value = null;
   /**

--- a/attractions/rollup.config.js
+++ b/attractions/rollup.config.js
@@ -72,6 +72,7 @@ export default [
       sveld({
         typesOptions: {
           preamble: 'export * as utils from "./utils";\n',
+          outDir: '.',
         },
       }),
       {

--- a/attractions/snackbar/snackbar-container.svelte
+++ b/attractions/snackbar/snackbar-container.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @slot {{ showSnackbar: (options: {
-   *   component: typeof import("svelte").SvelteComponentDev,
+   *   component: typeof import('svelte').SvelteComponentDev,
    *   props: Record<string, any>,
    *   duration: number,
    * }) => {
@@ -16,7 +16,7 @@
 
   /**
    * The position of the snackbar stack inside the container.
-   * @type {typeof import('../../snackbar').SnackbarPositions}
+   * @type {typeof import('./snackbar-positions').default}
    */
   export let position = SnackbarPositions.BOTTOM_LEFT;
   let registeredSnackbars = new Set();
@@ -32,7 +32,7 @@
   /**
    * Show the snackbar with the given options
    * @type {(options: {
-   *   component: typeof import("svelte").SvelteComponentDev,
+   *   component: typeof import('svelte').SvelteComponentDev,
    *   props: Record<string, any>,
    *   duration: number,
    * }) => {

--- a/attractions/snackbar/snackbar-container.svelte
+++ b/attractions/snackbar/snackbar-container.svelte
@@ -1,8 +1,8 @@
 <script>
   /**
-   * @slot {{ showSnackbar: (options: {
-   *   component: typeof import('svelte').SvelteComponentDev,
-   *   props: Record<string, any>,
+   * @slot {{ showSnackbar: <Props extends Record<string, any>>(options: {
+   *   component: import('svelte').SvelteComponentTyped<Props>,
+   *   props: Props,
    *   duration: number,
    * }) => {
    *   close: () => void,
@@ -31,9 +31,9 @@
 
   /**
    * Show the snackbar with the given options
-   * @type {(options: {
-   *   component: typeof import('svelte').SvelteComponentDev,
-   *   props: Record<string, any>,
+   * @type {<Props extends Record<string, any>>(options: {
+   *   component: import('svelte').SvelteComponentTyped<Props>,
+   *   props: Props,
    *   duration: number,
    * }) => {
    *   close: () => void,

--- a/attractions/snackbar/snackbar.svelte
+++ b/attractions/snackbar/snackbar.svelte
@@ -8,12 +8,12 @@
   export { _class as class };
   /**
    * A class string to add to the label of the snackbar.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let textClass = null;
   /**
    * A class string to add to the action button of the snackbar.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let buttonClass = null;
 
@@ -24,7 +24,7 @@
   export let text;
   /**
    * The action for the button on the snackbar. If this is null, the button is not rendered. Otherwise it has text as a label and calls callback on click.
-   * @type {{ text: string; callback: () => void }}
+   * @type {{ text: string; callback: () => void } | null}
    */
   export let action = null;
   /**

--- a/attractions/star-rating/star-rating.svelte
+++ b/attractions/star-rating/star-rating.svelte
@@ -13,7 +13,7 @@
   export { _class as class };
   /**
    * A class string to assign to the `<label>` element containing the star icon.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let starClass = null;
 
@@ -24,7 +24,7 @@
   export let max = 5;
   /**
    * Current amount of selected stars.
-   * @type {number}
+   * @type {number | null}
    */
   export let value = null;
   /**

--- a/attractions/star-rating/star-rating.svelte
+++ b/attractions/star-rating/star-rating.svelte
@@ -24,9 +24,9 @@
   export let max = 5;
   /**
    * Current amount of selected stars.
-   * @type {number | null}
+   * @type {number}
    */
-  export let value = null;
+  export let value = 0;
   /**
    * The name to assign to all stars belonging to the same group. Check [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname) for more information.
    * @type {string}

--- a/attractions/switch/switch.svelte
+++ b/attractions/switch/switch.svelte
@@ -9,17 +9,17 @@
   export { _class as class };
   /**
    * A class string to add to the `<input>` inside.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let inputClass = null;
   /**
    * A class string to add to the [track](https://material.io/components/selection-controls#switches) of the switch.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let trackClass = null;
   /**
    * A class string to add to the [thumb](https://material.io/components/selection-controls#switches) of the switch.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let thumbClass = null;
 

--- a/attractions/tab/tab.svelte
+++ b/attractions/tab/tab.svelte
@@ -11,12 +11,12 @@
   export { _class as class };
   /**
    * A class string to assign to the `<input>` element.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let inputClass = null;
   /**
    * A class string to add to the content of the tab.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let contentClass = null;
 
@@ -27,12 +27,12 @@
   export let value;
   /**
    * The name assigned to the `<input type="radio">`'s [name attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
-   * @type {string}
+   * @type {string | null}
    */
   export let name = null;
   /**
    * The `value` of the currently selected tab. Use with `bind:group`.
-   * @type {string}
+   * @type {string | null}
    */
   export let group = null;
   /**

--- a/attractions/tab/tabs.svelte
+++ b/attractions/tab/tabs.svelte
@@ -9,13 +9,13 @@
   export { _class as class };
   /**
    * A class string to pass to each `<Tab>` component.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let tabClass = null;
 
   /**
    * The currently selected tab.
-   * @type {string}
+   * @type {string | null}
    */
   export let value = null;
   /**

--- a/attractions/text-field/text-field.svelte
+++ b/attractions/text-field/text-field.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
-   * @event {{ value: string | number; nativeEvent: Event }} input
-   * @event {{ value: string | number; nativeEvent: Event }} change
+   * @event {{ value: string | number | null; nativeEvent: Event }} input
+   * @event {{ value: string | number | null; nativeEvent: Event }} change
    * @event {{ nativeEvent: FocusEvent }} focus
    * @event {{ nativeEvent: KeyboardEvent }} keydown
    * @event {{ nativeEvent: FocusEvent }} blur
@@ -63,7 +63,7 @@
   export let label = null;
   /**
    * The error message to show under the text field.
-   * @type {string | null}
+   * @type {string | false | null}
    */
   export let error = null;
   /**

--- a/attractions/text-field/text-field.svelte
+++ b/attractions/text-field/text-field.svelte
@@ -15,17 +15,17 @@
   export { _class as class };
   /**
    * A class string to assign to the `<input>` or `<textarea>` element.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let inputClass = null;
   /**
    * A class string to assign to the `<label>` for the outline text fields.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let labelClass = null;
   /**
    * A class string to add to the error message under the text field.
-   * @type {string}
+   * @type {string | false | null}
    */
   export let errorClass = null;
 
@@ -48,7 +48,7 @@
 
   /**
    * The ID to assign to the input.
-   * @type {string}
+   * @type {string | null}
    */
   export let id = null;
   /**
@@ -58,12 +58,12 @@
   export let noSpinner = false;
   /**
    * The label to show above the text field. Only works with `outline` text fields.
-   * @type {string}
+   * @type {string | null}
    */
   export let label = null;
   /**
    * The error message to show under the text field.
-   * @type {string}
+   * @type {string | null}
    */
   export let error = null;
   /**
@@ -83,7 +83,7 @@
 
   /**
    * The current value of the text field. Converted to a number if `type="number"`.
-   * @type {string | number}
+   * @type {string | number | null}
    */
   export let value = null;
   /**

--- a/attractions/time-picker/time-picker.svelte
+++ b/attractions/time-picker/time-picker.svelte
@@ -34,7 +34,7 @@
   export let right = false;
   /**
    * The currently selected time value. Even though a whole `Date` object is needed, only the time part will be considered.
-   * @type {Date}
+   * @type {Date | null}
    */
   export let value = null;
   /**

--- a/attractions/tsconfig.json
+++ b/attractions/tsconfig.json
@@ -23,6 +23,6 @@
     // Types should go into this directory.
     // Removing this would place the .d.ts files
     // next to the .js files
-    "outDir": "types"
+    "outDir": "."
   }
 }

--- a/attractions/tsconfig.json
+++ b/attractions/tsconfig.json
@@ -9,6 +9,7 @@
     "./dist"
   ],
   "compilerOptions": {
+    "strictNullChecks": true,
     // Tells TypeScript to read JS files, as
     // normally they are ignored as source files
     "allowJs": true,

--- a/attractions/tsconfig.json
+++ b/attractions/tsconfig.json
@@ -1,7 +1,13 @@
 {
   // Change this to match your project
-  "include": ["utils/*.js"],
-
+  "include": ["./**/*.js"],
+  "exclude": [
+    "node_modules",
+    "./rollup.config.js",
+    "./svelte.config.js",
+    "./check-version.js",
+    "./dist"
+  ],
   "compilerOptions": {
     // Tells TypeScript to read JS files, as
     // normally they are ignored as source files
@@ -11,9 +17,12 @@
     // This compiler run should
     // only output d.ts files
     "emitDeclarationOnly": true,
+    // Generate source maps to link back to definition
+    // Useful for "jump to definition"
+    "declarationMap": true,
     // Types should go into this directory.
     // Removing this would place the .d.ts files
     // next to the .js files
-    "outDir": "types/utils"
+    "outDir": "types"
   }
 }

--- a/attractions/utils/accepted-file-type.js
+++ b/attractions/utils/accepted-file-type.js
@@ -1,6 +1,6 @@
 /**
  * Validates a File object against an `accept` parameter value.
- * @param {?string} references comma-delimited list of reference MIME types (similar to `input`'s `accept` attribute)
+ * @param {string | null} references comma-delimited list of reference MIME types (similar to `input`'s `accept` attribute)
  * @param {string} subject The MIME type of the file to be checked
  * @returns {boolean} Whether the file should be accepted
  */

--- a/attractions/utils/accepted-file-type.js
+++ b/attractions/utils/accepted-file-type.js
@@ -1,6 +1,6 @@
 /**
  * Validates a File object against an `accept` parameter value.
- * @param {string} references comma-delimited list of reference MIME types (similar to `input`'s `accept` attribute)
+ * @param {?string} references comma-delimited list of reference MIME types (similar to `input`'s `accept` attribute)
  * @param {string} subject The MIME type of the file to be checked
  * @returns {boolean} Whether the file should be accepted
  */

--- a/attractions/utils/call-on-sight.js
+++ b/attractions/utils/call-on-sight.js
@@ -2,8 +2,9 @@
  * Action that allows calling a function when an element appears in the viewport.
  * Uses the IntersectionObserver API, which might not be available in older browsers like IE11.
  * If it is not available, the action will be silently ignored.
+ * @template T
  * @param {Element} node The HTML element to be observed
- * @param {{ callback: (...args: any[]) => void; args: any[] }} options Callback and its args
+ * @param {{ callback: (...args: T[]) => void; args: T[] }} options Callback and its args
  * @returns {{ destroy: () => void }}
  */
 export default function callOnSight(node, { callback, args = [] }) {

--- a/attractions/utils/call-on-sight.js
+++ b/attractions/utils/call-on-sight.js
@@ -2,9 +2,8 @@
  * Action that allows calling a function when an element appears in the viewport.
  * Uses the IntersectionObserver API, which might not be available in older browsers like IE11.
  * If it is not available, the action will be silently ignored.
- * @template T
  * @param {Element} node The HTML element to be observed
- * @param {{ callback: (...args: T[]) => void; args: T[] }} options Callback and its args
+ * @param {{ callback: (...args: any[]) => void; args: any[] }} options Callback and its args
  * @returns {{ destroy: () => void }}
  */
 export default function callOnSight(node, { callback, args = [] }) {

--- a/attractions/utils/classes.js
+++ b/attractions/utils/classes.js
@@ -11,7 +11,7 @@ export function stripClassWhitespace(classString) {
 
 /**
  * Filters out falsy classes.
- * @param {...(string | false)} args The classes to be filtered
+ * @param {...(string | false | null)} args The classes to be filtered
  * @return {string} The classes without the falsy values
  */
 export default function classes(...args) {

--- a/attractions/utils/color-picker-styles.js
+++ b/attractions/utils/color-picker-styles.js
@@ -2,7 +2,7 @@
  * Generates the styles needed for displaying a radiobutton or a checkbox
  *  with the given color.
  * @param {string} hexColor The color (in `#XXXXXX` format)
- * @returns {string} The `style` string to be used on the element
+ * @returns {?string} The `style` string to be used on the element
  */
 export default function getColorPickerStyles(hexColor) {
   if (hexColor == null) {

--- a/attractions/utils/color-picker-styles.js
+++ b/attractions/utils/color-picker-styles.js
@@ -2,7 +2,7 @@
  * Generates the styles needed for displaying a radiobutton or a checkbox
  *  with the given color.
  * @param {string} hexColor The color (in `#XXXXXX` format)
- * @returns {?string} The `style` string to be used on the element
+ * @returns {string | null} The `style` string to be used on the element
  */
 export default function getColorPickerStyles(hexColor) {
   if (hexColor == null) {

--- a/attractions/utils/datetime-utils.js
+++ b/attractions/utils/datetime-utils.js
@@ -7,7 +7,7 @@ const daysInWeek = 7;
  * @param {string} string The date-time string to be parsed
  * @param {string} format The format against which to parse the date-time string
  * @param {Date} [defaultValue] If the string cannot be properly parsed against the format string, this is returned
- * @returns {?Date} The date object representing the given string
+ * @returns {Date | null} The date object representing the given string
  */
 export function parseDateTime(string, format, defaultValue) {
   const century = Math.floor(new Date().getFullYear() / 100);
@@ -158,8 +158,8 @@ export function getWeekdays(locale, firstWeekday) {
 
 /**
  * Check for equality between 2 `Date` objects, disregarding the time.
- * @param {?Date} date1
- * @param {?Date} date2
+ * @param {Date | null} date1
+ * @param {Date | null} date2
  * @returns {boolean}
  */
 export function datesEqual(date1, date2) {
@@ -176,8 +176,8 @@ export function datesEqual(date1, date2) {
 
 /**
  * Check for equality between 2 `Date` objects, including the time (hours, minutes, and seconds only).
- * @param {?Date} date1
- * @param {?Date} date2
+ * @param {Date | null} date1
+ * @param {Date | null} date2
  * @returns {boolean}
  */
 export function dateTimesEqual(dt1, dt2) {
@@ -191,8 +191,8 @@ export function dateTimesEqual(dt1, dt2) {
 
 /**
  * Checks if the date of the first `Date` object came before the date of the second (disregards time).
- * @param {?Date} date1
- * @param {?Date} date2
+ * @param {Date | null} date1
+ * @param {Date | null} date2
  * @returns {boolean}
  */
 export function datesLessEqual(date1, date2) {
@@ -240,9 +240,9 @@ export function getCalendar(month, year, firstWeekday) {
 
 /**
  * Copies the date (day, month, and year) from the first `Date` object to the second.
- * @param {?Date} source The object to copy the date from
- * @param {?Date} destination The object to which the date will be copied, modified in-place
- * @returns {?Date} The modified object
+ * @param {Date | null} source The object to copy the date from
+ * @param {Date | null} destination The object to which the date will be copied, modified in-place
+ * @returns {Date | null} The modified object
  */
 export function applyDate(source, destination) {
   if (source == null || destination == null) {
@@ -258,9 +258,9 @@ export function applyDate(source, destination) {
 
 /**
  * Copies the time (hour, minute, and second) from the first `Date` object to the second.
- * @param {?Date} source The object to copy the time from
- * @param {?Date} destination The object to which the time will be copied, modified in-place
- * @returns {?Date} The modified object
+ * @param {Date | null} source The object to copy the time from
+ * @param {Date | null} destination The object to which the time will be copied, modified in-place
+ * @returns {Date | null} The modified object
  */
 export function applyTime(source, destination) {
   if (source == null || destination == null) {
@@ -276,8 +276,8 @@ export function applyTime(source, destination) {
 
 /**
  * Copy a Date object, respecting null values.
- * @param {?Date} date The object from which a copy should be made
- * @returns {?Date} The clone of the given object
+ * @param {Date | null} date The object from which a copy should be made
+ * @returns {Date | null} The clone of the given object
  */
 export function copyDate(date) {
   if (date == null) {

--- a/attractions/utils/datetime-utils.js
+++ b/attractions/utils/datetime-utils.js
@@ -6,8 +6,8 @@ const daysInWeek = 7;
  * Parses a string representing a timestamp using the given format into a `Date` object.
  * @param {string} string The date-time string to be parsed
  * @param {string} format The format against which to parse the date-time string
- * @param {Date} defaultValue If the string cannot be properly parsed against the format string, this is returned
- * @returns {Date} The date object representing the given string
+ * @param {Date} [defaultValue] If the string cannot be properly parsed against the format string, this is returned
+ * @returns {?Date} The date object representing the given string
  */
 export function parseDateTime(string, format, defaultValue) {
   const century = Math.floor(new Date().getFullYear() / 100);
@@ -158,8 +158,8 @@ export function getWeekdays(locale, firstWeekday) {
 
 /**
  * Check for equality between 2 `Date` objects, disregarding the time.
- * @param {Date} date1
- * @param {Date} date2
+ * @param {?Date} date1
+ * @param {?Date} date2
  * @returns {boolean}
  */
 export function datesEqual(date1, date2) {
@@ -176,8 +176,8 @@ export function datesEqual(date1, date2) {
 
 /**
  * Check for equality between 2 `Date` objects, including the time (hours, minutes, and seconds only).
- * @param {Date} date1
- * @param {Date} date2
+ * @param {?Date} date1
+ * @param {?Date} date2
  * @returns {boolean}
  */
 export function dateTimesEqual(dt1, dt2) {
@@ -191,8 +191,8 @@ export function dateTimesEqual(dt1, dt2) {
 
 /**
  * Checks if the date of the first `Date` object came before the date of the second (disregards time).
- * @param {Date} date1
- * @param {Date} date2
+ * @param {?Date} date1
+ * @param {?Date} date2
  * @returns {boolean}
  */
 export function datesLessEqual(date1, date2) {
@@ -240,9 +240,9 @@ export function getCalendar(month, year, firstWeekday) {
 
 /**
  * Copies the date (day, month, and year) from the first `Date` object to the second.
- * @param {Date} source The object to copy the date from
- * @param {Date} destination The object to which the date will be copied, modified in-place
- * @returns {Date} The modified object
+ * @param {?Date} source The object to copy the date from
+ * @param {?Date} destination The object to which the date will be copied, modified in-place
+ * @returns {?Date} The modified object
  */
 export function applyDate(source, destination) {
   if (source == null || destination == null) {
@@ -258,9 +258,9 @@ export function applyDate(source, destination) {
 
 /**
  * Copies the time (hour, minute, and second) from the first `Date` object to the second.
- * @param {Date} source The object to copy the time from
- * @param {Date} destination The object to which the time will be copied, modified in-place
- * @returns {Date} The modified object
+ * @param {?Date} source The object to copy the time from
+ * @param {?Date} destination The object to which the time will be copied, modified in-place
+ * @returns {?Date} The modified object
  */
 export function applyTime(source, destination) {
   if (source == null || destination == null) {
@@ -276,8 +276,8 @@ export function applyTime(source, destination) {
 
 /**
  * Copy a Date object, respecting null values.
- * @param {Date} date The object from which a copy should be made
- * @returns {Date} The clone of the given object
+ * @param {?Date} date The object from which a copy should be made
+ * @returns {?Date} The clone of the given object
  */
 export function copyDate(date) {
   if (date == null) {

--- a/attractions/utils/dynamic-transition.js
+++ b/attractions/utils/dynamic-transition.js
@@ -1,9 +1,12 @@
 /**
+ * @typedef {{ delay: number; duration: number; css: () => string }} Transition
+ */
+/**
  * Create a transition that allows specifying a transition programmatically
  *  or disable it altogether.
- * @typedef {{ delay: number; duration: number; css: () => string }} Transition
+ * @template T
  * @param {Element} node
- * @param {{ transition: (node: Element; options: any) => Transition; options: any }} options
+ * @param {{ transition: (node: Element; options: T) => Transition; options: T }} options
  * @returns {Transition}
  */
 export default function dynamic(node, { transition = null, options = null }) {

--- a/attractions/utils/range.js
+++ b/attractions/utils/range.js
@@ -1,8 +1,8 @@
 /**
  * Generates a semi-open range.
  * @param {number} start The beginning of the range (included)
- * @param {number} end The end of the range (excluded)
- * @param {number} step The distance between the numbers in the range
+ * @param {number} [end] The end of the range (excluded)
+ * @param {number} [step=1] The distance between the numbers in the range
  * @returns {Generator<number, void, never>}
  */
 export default function* range(start, end, step = 1) {

--- a/attractions/utils/ripple.js
+++ b/attractions/utils/ripple.js
@@ -2,7 +2,7 @@
  * Create a ripple action
  * @typedef {{ event?: string; transition?: number; zIndex?: string; rippleColor?: string; disabled?: boolean }} Options
  * @param {Element} node
- * @param {Options} options
+ * @param {Options} [options={}]
  * @returns {{ destroy: () => void; update: (options?: Options) => void }}
  */
 export default function ripple(node, options = {}) {


### PR DESCRIPTION
The _types_ folder was not being picked up by TypeScript as it is not something special for it (unlike `@types/attractions`, but that's for when the types are unofficial and contributed by the community). Apparently, the `"types"` field of _package.json_ is only used for the main import, i.e.: `import { Button } from "attractions";`, and not when importing submodules, i.e.: `import { classes } from "attractions/utils";`. It refers only to a file (_index.d.ts_). Everything else in the directory not being directly imported by it is ignored.

It was also not possible to add type declarations for a module when its untyped (JS) source code exists next to it. In other words, we cannot write `declare module "attractions/utils" { /* ... */ }` in _index.d.ts_ since the actual _utils_ (source code) folder exists and it doesn't have types.

Therefore, the solution implemented here just puts the type declarations right next to their source code while being gitignored. This way, any js/svelte file has its types right next to it and can be imported directly, not just through the root `"attractions"` module.
This also has the added benefit that the type imports paths are now the same inside the _svelte_ files and don't try to `../..` their way out of the _types_ folder (looking at snackbar/popover positions in particular)