### PR TITLE
Fix the import style in the docs

### DIFF
--- a/docs/src/routes/docs/installation.svx
+++ b/docs/src/routes/docs/installation.svx
@@ -207,7 +207,7 @@ module.exports = {
 
 ```js
 import svelte from 'rollup-plugin-svelte';
-import svelteConfig from './svelte.config.js';
+const svelteConfig = require('./svelte.config.js');  // it has to be a CommonJS import
 
 export default {
   // ...,
@@ -226,7 +226,7 @@ export default {
 
 ```js
 import svelte from 'rollup-plugin-svelte';
-import svelteConfig from './svelte.config.js';
+const svelteConfig = require('./svelte.config.js');  // it has to be a CommonJS import
 
 export default {
   client: {


### PR DESCRIPTION
Importing `svelte.config.js` with an ES6 import doesn't work for some reason.

Related to #240 