### PR TITLE
Bug: fix getCalendar day cursor in short months

### DIFF
--- a/attractions/utils/datetime-utils.js
+++ b/attractions/utils/datetime-utils.js
@@ -215,14 +215,12 @@ export function datesLessEqual(date1, date2) {
  */
 export function getCalendar(month, year, firstWeekday) {
   const calendar = [];
-  const dayCursor = new Date(0);
-  dayCursor.setFullYear(year, month);
+  const dayCursor = new Date();
 
   // Offset the start of the month to the closest left `firstWeekday`
-  dayCursor.setDate(
-    1 - ((daysInWeek + dayCursor.getDay() - firstWeekday) % daysInWeek)
-  );
-
+  const date = 1 - ((daysInWeek + dayCursor.getDay() - firstWeekday) % daysInWeek);
+  dayCursor.setFullYear(year, month, date);
+  
   do {
     const week = [];
     for (let i = 0; i < daysInWeek; ++i) {

--- a/attractions/utils/datetime-utils.js
+++ b/attractions/utils/datetime-utils.js
@@ -216,11 +216,13 @@ export function datesLessEqual(date1, date2) {
 export function getCalendar(month, year, firstWeekday) {
   const calendar = [];
   const dayCursor = new Date();
+  dayCursor.setFullYear(year, month, 1);
 
   // Offset the start of the month to the closest left `firstWeekday`
-  const date = 1 - (firstWeekday % daysInWeek);
-  dayCursor.setFullYear(year, month, date);
-  
+  dayCursor.setDate(
+    0 - ((dayCursor.getDay() + firstWeekday) % daysInWeek)
+  );
+
   do {
     const week = [];
     for (let i = 0; i < daysInWeek; ++i) {

--- a/attractions/utils/datetime-utils.js
+++ b/attractions/utils/datetime-utils.js
@@ -218,7 +218,7 @@ export function getCalendar(month, year, firstWeekday) {
   const dayCursor = new Date();
 
   // Offset the start of the month to the closest left `firstWeekday`
-  const date = 1 - ((daysInWeek + dayCursor.getDay() - firstWeekday) % daysInWeek);
+  const date = 1 - (firstWeekday % daysInWeek);
   dayCursor.setFullYear(year, month, date);
   
   do {

--- a/attractions/utils/datetime-utils.js
+++ b/attractions/utils/datetime-utils.js
@@ -145,7 +145,7 @@ export function getWeekdays(locale, firstWeekday) {
   const weekdayFormatter = new Intl.DateTimeFormat(locale, {
     weekday: 'short',
   });
-  const anchor = new Date(0); // Initially set to the UNIX epoch – Thursday
+  const anchor = new Date(1970, 0, 1); // Initially set to the UNIX epoch – Thursday
   const mondayOffset = 5; // How many days to add to the epoch to get a Monday
   const weekdays = [];
   for (let i = 0; i < daysInWeek; ++i) {
@@ -215,12 +215,12 @@ export function datesLessEqual(date1, date2) {
  */
 export function getCalendar(month, year, firstWeekday) {
   const calendar = [];
-  const dayCursor = new Date();
-  dayCursor.setFullYear(year, month, 1);
+  const dayCursor = new Date(1970, 0, 1);
+  dayCursor.setFullYear(year, month);
 
   // Offset the start of the month to the closest left `firstWeekday`
   dayCursor.setDate(
-    0 - ((dayCursor.getDay() + firstWeekday) % daysInWeek)
+    1 - ((daysInWeek + dayCursor.getDay() - firstWeekday) % daysInWeek)
   );
 
   do {

--- a/attractions/utils/datetime-utils.js
+++ b/attractions/utils/datetime-utils.js
@@ -215,8 +215,7 @@ export function datesLessEqual(date1, date2) {
  */
 export function getCalendar(month, year, firstWeekday) {
   const calendar = [];
-  const dayCursor = new Date(1970, 0, 1);
-  dayCursor.setFullYear(year, month);
+  const dayCursor = new Date(year, month, 1);
 
   // Offset the start of the month to the closest left `firstWeekday`
   dayCursor.setDate(


### PR DESCRIPTION
- Create day cursor in local timezone

For more discussion see #243 