### PR TITLE
Adds variables to customize buttons & textfield outline

### DIFF
--- a/attractions/_appearances.scss
+++ b/attractions/_appearances.scss
@@ -43,7 +43,7 @@
 
 @mixin button {
   font-family: vars.$font;
-  font-weight: vars.$bold-font-weight;
+  font-weight: vars.$button-font-weight;
   outline: none;
   display: flex;
   align-items: center;

--- a/attractions/_variables.scss
+++ b/attractions/_variables.scss
@@ -39,7 +39,7 @@ $snackbar-vertical-offset: 3em !default;
 $bold-font-weight: 500 !default;
 $regular-font-weight: 400 !default;
 $thin-font-weight: 300 !default;
-$button-font-weight: $bold-font-weight !default;
+$button-font-weight: 500 !default;
 
 $shadow-0: 0 2px 2px 0 color.adjust(black, $alpha: -0.86),
   0 1px 5px 0 color.adjust(black, $alpha: -0.88) !default;

--- a/attractions/_variables.scss
+++ b/attractions/_variables.scss
@@ -16,6 +16,7 @@ $badge-default: #ff5757 !default;
 $light-contrast: #ddd !default;
 $textfield-bg: #f5f5f5 !default;
 $textfield-bg-error: #fbeeee !default;
+$textfield-outline-label-bg: #fff !default;
 $textfield-border: color.adjust(black, $alpha: -0.58) !default;
 $textfield-item: #7a7a7a !default;
 $off-state: #aaa !default;
@@ -31,6 +32,7 @@ $dialog-radius: 1.5625em !default;
 $dropzone-radius: 1.5625em !default;
 $card-radius: 1.25em !default;
 $file-tile-radius: 0.625em !default;
+$textfield-outline-radius: 1.5625em !default;
 
 $snackbar-horizontal-offset: 5% !default;
 $snackbar-vertical-offset: 3em !default;

--- a/attractions/_variables.scss
+++ b/attractions/_variables.scss
@@ -16,7 +16,6 @@ $badge-default: #ff5757 !default;
 $light-contrast: #ddd !default;
 $textfield-bg: #f5f5f5 !default;
 $textfield-bg-error: #fbeeee !default;
-$textfield-outline-label-bg: #fff !default;
 $textfield-border: color.adjust(black, $alpha: -0.58) !default;
 $textfield-item: #7a7a7a !default;
 $off-state: #aaa !default;

--- a/attractions/_variables.scss
+++ b/attractions/_variables.scss
@@ -40,6 +40,7 @@ $snackbar-vertical-offset: 3em !default;
 $bold-font-weight: 500 !default;
 $regular-font-weight: 400 !default;
 $thin-font-weight: 300 !default;
+$button-font-weight: $bold-font-weight !default;
 
 $shadow-0: 0 2px 2px 0 color.adjust(black, $alpha: -0.86),
   0 1px 5px 0 color.adjust(black, $alpha: -0.88) !default;

--- a/attractions/text-field/text-field.scss
+++ b/attractions/text-field/text-field.scss
@@ -119,7 +119,7 @@
 
     label {
       font-family: vars.$font;
-      background-color: vars.$textfield-outline-label-bg;
+      background-color: vars.$background;
       color: vars.$textfield-border;
       padding: 0 0.25em;
       position: absolute;

--- a/attractions/text-field/text-field.scss
+++ b/attractions/text-field/text-field.scss
@@ -126,6 +126,7 @@
       top: 0;
       left: 1.4em;
       transform: translate(-0.25em, -55%);
+      border-radius: 0.3125em;
     }
 
     &.with-item.left {

--- a/attractions/text-field/text-field.scss
+++ b/attractions/text-field/text-field.scss
@@ -119,14 +119,13 @@
 
     label {
       font-family: vars.$font;
-      background-color: #fff;
+      background-color: vars.$textfield-outline-label-bg;
       color: vars.$textfield-border;
       padding: 0 0.25em;
       position: absolute;
       top: 0;
       left: 1.4em;
       transform: translate(-0.25em, -55%);
-      border-radius: 0.3125em;
     }
 
     &.with-item.left {
@@ -148,7 +147,7 @@
     }
 
     input {
-      border-radius: 1.5625em;
+      border-radius: vars.$textfield-outline-radius;
       border: 1px solid vars.$textfield-border;
       background-color: transparent;
       padding: 0 1.4em;

--- a/docs/src/routes/docs/components/button.svx
+++ b/docs/src/routes/docs/components/button.svx
@@ -133,6 +133,6 @@ The content of the Button. Icons, other components, everything is fair game here
 | **`$shadow-raised`** | The shadow of filled buttons on hover. | <ShadowPreview value={shadowRaised} /> |
 | **`$disabled`** | The text color of disabled buttons. | <ColorPreview value="#888888" /> |
 | **`$disabled-bg`** | The background color of filled disabled buttons. | <ColorPreview value="#D7D7D7" /> |
-| **`$bold-font-weight`** | The font weight of the buttons. | `500` |
+| **`$button-font-weight`** | The font weight of the buttons. | `$bold-font-weight` (`500`) |
 
 <style src="../../../../static/css/routes/docs/components/button.scss"></style>

--- a/docs/src/routes/docs/components/button.svx
+++ b/docs/src/routes/docs/components/button.svx
@@ -133,6 +133,6 @@ The content of the Button. Icons, other components, everything is fair game here
 | **`$shadow-raised`** | The shadow of filled buttons on hover. | <ShadowPreview value={shadowRaised} /> |
 | **`$disabled`** | The text color of disabled buttons. | <ColorPreview value="#888888" /> |
 | **`$disabled-bg`** | The background color of filled disabled buttons. | <ColorPreview value="#D7D7D7" /> |
-| **`$button-font-weight`** | The font weight of the buttons. | `$bold-font-weight` (`500`) |
+| **`$button-font-weight`** | The font weight of the buttons. | `500` |
 
 <style src="../../../../static/css/routes/docs/components/button.scss"></style>

--- a/docs/src/routes/docs/components/text-field.svx
+++ b/docs/src/routes/docs/components/text-field.svx
@@ -129,5 +129,7 @@ If the <mark>`withItem`</mark> property is specified, this holds the item for th
 | **`$thin-font-weight`** | The thin font weight for the text inside the text field. | `300` |
 | **`$bold-font-weight`** | The bold font weight for the error text and the item that's positioned to the left of the input area. | `500` |
 | **`$x-icon`** | **Only applicable to `<input type="search">` in WebKit browsers**. If you wish to use a custom icon for the X that clears the field's value, supply a URL to the icon here. | [Feather Icons' X](https://feathericons.com/?query=x) as a data URL |
+| **`$textfield-outline-radius`** | The `border-radius` of the text field when using the `outline` variant | `1.5625em` |
+| **`$textfield-outline-label-bg`** | The `background-color` of the associated label when using the `outline` variant | `#fff` |
 
 <style src="../../../../static/css/routes/docs/components/text-field.scss"></style>

--- a/docs/src/routes/docs/components/text-field.svx
+++ b/docs/src/routes/docs/components/text-field.svx
@@ -130,6 +130,5 @@ If the <mark>`withItem`</mark> property is specified, this holds the item for th
 | **`$bold-font-weight`** | The bold font weight for the error text and the item that's positioned to the left of the input area. | `500` |
 | **`$x-icon`** | **Only applicable to `<input type="search">` in WebKit browsers**. If you wish to use a custom icon for the X that clears the field's value, supply a URL to the icon here. | [Feather Icons' X](https://feathericons.com/?query=x) as a data URL |
 | **`$textfield-outline-radius`** | The `border-radius` of the text field when using the `outline` variant | `1.5625em` |
-| **`$textfield-outline-label-bg`** | The `background-color` of the associated label when using the `outline` variant | `#fff` |
 
 <style src="../../../../static/css/routes/docs/components/text-field.scss"></style>


### PR DESCRIPTION
* Introduces a new variable, `$button-font-weight`, to allow changing the `font-weight` of a `<Button>`.
* Introduces a new variable, `$textfield-outline-radius`, to allow changing the `border-radius` of a `<TextField outline>`.
* ~~Introduces a new variable, `$textfield-outline-label-bg`, to allow changing the `background-color` of a `label` in a `<TextField outline>`.~~

* Closes #245 
* Closes #246 