### PR TITLE
Fix the types of exported functions

### DIFF
--- a/attractions/dropdown/dropdown-shell.svelte
+++ b/attractions/dropdown/dropdown-shell.svelte
@@ -17,7 +17,6 @@
   /**
    * A callback to toggle the open state of the dropdown.
    * @type {() => void}
-   * @readonly
    */
   export function toggle() {
     open = !open;

--- a/attractions/snackbar/snackbar-container.svelte
+++ b/attractions/snackbar/snackbar-container.svelte
@@ -40,7 +40,6 @@
    *   close: () => void,
    *   expired: Promise<boolean>,
    * }}
-   * @readonly
    */
   export function showSnackbar(options) {
     const { component = Snackbar, props = {}, duration = 4000 } = options;


### PR DESCRIPTION
Sveld has been updated and they are no longer detected as props.
The `@readonly` annotation was still preventing it from detecting properly.