### PR TITLE
Create a `Table` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Added
 
 - The [`Breadcrumbs`](https://illright.github.io/attractions/docs/components/breadcrumbs) component has been added to the library ([#157](https://github.com/illright/attractions/issues/157)).
+- A new [`Table`](https://illright.github.io/attractions/docs/components/table) component has been added, useful for displaying simple collections of data ([#255](https://github.com/illright/attractions/issues/255)).
 - `maxReachedTooltip` prop for the `CheckboxGroup` and `CheckboxChipGroup` components to customize the tooltip text that appears on hover when the maximum amount of checkboxes have been checked ([#13](https://github.com/illright/attractions/issues/13)).
 - The `hours`, `minutes` and `seconds` props of the `TimePicker` component allow you to specify what values the user can choose from ([#120](https://github.com/illright/attractions/issues/120)).
 - `disabledDates` prop for the `Calendar` component to disable specific dates or ranges of dates ([#34](https://github.com/illright/attractions/issues/34)).
 - `inputClass` prop for the `TimePicker` and `DatePicker` components to pass them down to the `TextField` ([#269](https://github.com/illright/attractions/issues/269)).
+- The [`Button`](https://illright.github.io/attractions/docs/components/button) component is now SvelteKit-compatible (using the `noPrefetch` prop would also unset `sveltekit:prefetch`).
 
 ### Fixed
 

--- a/attractions/_variables.scss
+++ b/attractions/_variables.scss
@@ -32,6 +32,7 @@ $dropzone-radius: 1.5625em !default;
 $card-radius: 1.25em !default;
 $file-tile-radius: 0.625em !default;
 $textfield-outline-radius: 1.5625em !default;
+$table-radius: 0.5em !default;
 
 $snackbar-horizontal-offset: 5% !default;
 $snackbar-vertical-offset: 3em !default;

--- a/attractions/breadcrumbs/breadcrumbs.scss
+++ b/attractions/breadcrumbs/breadcrumbs.scss
@@ -7,7 +7,7 @@ nav {
   margin: 0 2em;
   font-weight: vars.$thin-font-weight;
 
-  & > :global .node {
+  > :global .node {
     margin: 0 0.25em;
   }
 }

--- a/attractions/index.js
+++ b/attractions/index.js
@@ -26,6 +26,8 @@ export { default as AccordionSection } from './accordion/accordion-section.svelt
 
 export { default as Modal } from './modal/modal.svelte';
 
+export { default as Table } from './table/table.svelte';
+
 export { default as Tab } from './tab/tab.svelte';
 export { default as Tabs } from './tab/tabs.svelte';
 

--- a/attractions/table/table.scss
+++ b/attractions/table/table.scss
@@ -1,0 +1,72 @@
+@use 'sass:color';
+@use 'node_modules/attractions/_variables' as vars;
+
+table {
+  border-spacing: 0;
+  border-collapse: separate;
+  display: block;
+  overflow-x: auto;
+  margin-bottom: 1em;
+
+  th {
+    text-align: start;
+    padding: 0.5em 1em;
+    &.center {
+      text-align: center;
+    }
+    &.end {
+      text-align: end;
+    }
+  }
+
+  tr {
+    &.alternating {
+      &:nth-child(even) {
+        background: color.adjust(vars.$main, $alpha: -0.97);
+      }
+    }
+
+    &:first-child :global {
+      > td:first-child {
+        border-top-left-radius: vars.$table-radius;
+      }
+
+      > td:last-child {
+        border-top-right-radius: vars.$table-radius;
+      }
+    }
+
+    &:last-child :global {
+      > td {
+        border-bottom-width: 1px;
+      }
+
+      > td:first-child {
+        border-bottom-left-radius: vars.$table-radius;
+      }
+
+      > td:last-child {
+        border-bottom-right-radius: vars.$table-radius;
+      }
+    }
+  }
+
+  td {
+    padding: 1em;
+    border: 0 solid color.adjust(vars.$main, $alpha: -0.75);
+    border-width: 1px 0 0 1px;
+    line-height: 1.3em;
+
+    text-align: start;
+    &.center {
+      text-align: center;
+    }
+    &.end {
+      text-align: end;
+    }
+
+    &:last-child {
+      border-right-width: 1px;
+    }
+  }
+}

--- a/attractions/table/table.scss
+++ b/attractions/table/table.scss
@@ -11,9 +11,11 @@ table {
   th {
     text-align: start;
     padding: 0.5em 1em;
+
     &.center {
       text-align: center;
     }
+
     &.end {
       text-align: end;
     }
@@ -58,9 +60,11 @@ table {
     line-height: 1.3em;
 
     text-align: start;
+
     &.center {
       text-align: center;
     }
+
     &.end {
       text-align: end;
     }

--- a/attractions/table/table.scss
+++ b/attractions/table/table.scss
@@ -28,7 +28,7 @@ table {
       }
     }
 
-    &:first-child :global {
+    &:first-child {
       > td:first-child {
         border-top-left-radius: vars.$table-radius;
       }
@@ -38,7 +38,7 @@ table {
       }
     }
 
-    &:last-child :global {
+    &:last-child {
       > td {
         border-bottom-width: 1px;
       }

--- a/attractions/table/table.svelte
+++ b/attractions/table/table.svelte
@@ -38,42 +38,36 @@
 </script>
 
 <table {...$$restProps}>
-  <slot>
-    <slot name="header">
-      <thead>
-        <tr>
-          {#each headers as header (header.value)}
-            <th
-              class:center={header.align === 'center'}
-              class:end={header.align === 'end'}
-            >
-              <Label>{header.text}</Label>
-            </th>
-          {/each}
-        </tr>
-      </thead>
-    </slot>
-    <slot name="body">
-      <tbody>
-        {#each items as item}
-          <slot name="row" {item}>
-            <tr class:alternating={alternatingRows}>
-              {#each headers as header (header.value)}
-                <slot name="item" {header} {item}>
-                  <td
-                    class:center={header.align === 'center'}
-                    class:end={header.align === 'end'}
-                  >
-                    {item[header.value]}
-                  </td>
-                </slot>
-              {/each}
-            </tr>
+  <thead>
+    <tr>
+      {#each headers as header (header.value)}
+        <th
+          class:center={header.align === 'center'}
+          class:end={header.align === 'end'}
+        >
+          <slot name="header-item" {header}>
+            <Label>{header.text}</Label>
           </slot>
+        </th>
+      {/each}
+    </tr>
+  </thead>
+  <tbody>
+    {#each items as item}
+      <tr class:alternating={alternatingRows}>
+        {#each headers as header (header.value)}
+          <td
+            class:center={header.align === 'center'}
+            class:end={header.align === 'end'}
+          >
+            <slot name="item" {header} {item}>
+              {item[header.value]}
+            </slot>
+          </td>
         {/each}
-      </tbody>
-    </slot>
-  </slot>
+      </tr>
+    {/each}
+  </tbody>
 </table>
 
 <style src="./table.scss">

--- a/attractions/table/table.svelte
+++ b/attractions/table/table.svelte
@@ -1,0 +1,75 @@
+<script>
+  import Label from '../typography/label.svelte';
+
+  /**
+   * @typedef {{
+   *  text: string;
+   *  value: string;
+   *  align?: "start" | "center" | "end";
+   * }} Header
+   * @typedef {{[value: string]: string | number}} Item
+   *
+   * @slot {{ header: Header; item: Item }} item
+   * @slot {{ item: Item }} row
+   */
+
+  /**
+   * The header row of the table. `text` is the text to display, and `value` is used to link the row data.
+   * @type {Array<Header>}
+   */
+  export let headers = [];
+  /**
+   * The actual data displayed in the table rows.
+   * The keys of the objects have to belong to the `value`s of the headers.
+   * @type {Array<Item>}
+   */
+  export let items = [];
+
+  /**
+   * Rows should have alternating background colors.
+   * @type {boolean}
+   */
+  export let alternatingRows = true;
+</script>
+
+<table {...$$restProps}>
+  <slot>
+    <slot name="header">
+      <thead>
+        <tr>
+          {#each headers as header (header.value)}
+            <th
+              class:center={header.align === 'center'}
+              class:end={header.align === 'end'}
+            >
+              <Label>{header.text}</Label>
+            </th>
+          {/each}
+        </tr>
+      </thead>
+    </slot>
+    <slot name="body">
+      <tbody>
+        {#each items as item}
+          <slot name="row" {item}>
+            <tr class:alternating={alternatingRows}>
+              {#each headers as header (header.value)}
+                <slot name="item" {header} {item}>
+                  <td
+                    class:center={header.align === 'center'}
+                    class:end={header.align === 'end'}
+                  >
+                    {item[header.value]}
+                  </td>
+                </slot>
+              {/each}
+            </tr>
+          </slot>
+        {/each}
+      </tbody>
+    </slot>
+  </slot>
+</table>
+
+<style src="./table.scss">
+</style>

--- a/attractions/table/table.svelte
+++ b/attractions/table/table.svelte
@@ -14,7 +14,12 @@
    */
 
   /**
-   * The header row of the table. `text` is the text to display, and `value` is used to link the row data.
+   * The labels for the column headers.
+   *
+   * Each column header is an object with the following fields:
+   * - `text` is the text to display;
+   * - `value` is the name of the field to take from each object in `items` to put in this column;
+   * - `align` is the alignment of the text in the column (`"start" | "center" | "end"`) and defaults to `"start"`.
    * @type {Array<Header>}
    */
   export let headers = [];
@@ -26,7 +31,7 @@
   export let items = [];
 
   /**
-   * Rows should have alternating background colors.
+   * Whether the table rows should have alternating background colors.
    * @type {boolean}
    */
   export let alternatingRows = true;

--- a/docs/src/routes/docs/_layout.svelte
+++ b/docs/src/routes/docs/_layout.svelte
@@ -144,6 +144,10 @@
           segment: 'components/switch',
         },
         {
+          title: 'Table',
+          segment: 'components/table',
+        },
+        {
           title: 'Tabs',
           segment: 'components/tabs',
         },

--- a/docs/src/routes/docs/components/table.svx
+++ b/docs/src/routes/docs/components/table.svx
@@ -72,7 +72,7 @@ const items = [
 
 | Name | Default | Type | Description |
 | ---- | ------- | ---- | ----------- |
-| **`headers`** | `[]` | <code>{headersType}</code> | The header row of the table. |
+| **`headers`** | `[]` | <code>{headersType}</code> | The labels for the column headers. Each column header is an object with the following fields:<br /><ul><li>`text` is the text to display;</li><li>`value` is the name of the field to take from each object in `items` to put in this column;</li><li>`align` is the alignment of the text in the column (`"start" &#124; "center" &#124; "end"`), defaulting to `"start"`.</li></ul> |
 | **`items`** | `[]` | <code>{itemsType}</code> | The actual rows of data to be displayed. It is an array of objects, where each object must have as its keys the content of the `value` property of the headers, and the value is the text to be displayed. |
 | **`...`** |  | `any` | Everything else will be passed to the underlying `<table>` element. |
 

--- a/docs/src/routes/docs/components/table.svx
+++ b/docs/src/routes/docs/components/table.svx
@@ -78,30 +78,17 @@ const items = [
 
 ## Slots {#slots}
 
-### Default slot
+### `header-item` slot
 
-The full content of the table. Providing this slot defeats the purpose of the component, but it can be useful if you want to make use of the same styles with highly customized content.
-Other -more refined- slots are also available for more convenience.
-
-### `header` slot
-
-The header row that defaults to a `<thead>` element with the row of headers.
-
-### `body` slot
-
-The entire body of the table that defaults to a `<tbody>` element.
-
-### `row` slot
-
-Customizes the entire row of data that defaults to a `<tr>` element.
+Customizes the content of the `<th>` elements. Defaults to a `<Label>` component with the text content of the header.
 
 | Prop Name | Type | Description |
 | --------- | ---- | ----------- |
-| **`item`** | <code>{itemType}</code> | The row object passed as part of the `items` array. |
+| **`header`** | <code>{headerType}</code> | The header object passed as part of the `headers` array. |
 
 ### `item` slot
 
-Used to customize each data cell on its own. This will probably be the most useful slot.
+Used to customize each data cell (contents of `<td>`) on its own.
 The intersection of `header` and `item` can be used to identify the data cell.
 
 | Prop Name | Type | Description |

--- a/docs/src/routes/docs/components/table.svx
+++ b/docs/src/routes/docs/components/table.svx
@@ -1,0 +1,117 @@
+---
+name: Table
+---
+
+<script>
+  import { Table } from 'attractions';
+  import Showcase from 'src/containers/docs/showcase.svelte';
+  import ColorPreview from 'src/components/docs/color-preview.svelte';
+
+  const headers = [
+    { text: 'First Name', value: 'firstName' },
+    { text: 'Last Name', value: 'lastName' },
+    { text: 'Age', value: 'age', align: 'end' },
+  ];
+  const items = [
+    { firstName: 'John', lastName: 'Doe', age: 694 },
+    { firstName: 'Leo', lastName: 'Tolstoy', age: new Date().getFullYear() - 1828 },
+    { firstName: 'فلان', lastName: 'الفلاني', age: 42 },
+    { firstName: 'Иван', lastName: 'Иванов', age: 69 },
+  ];
+  const headerType = '{ text: string; value: string}';
+  const headersType = `Array<{
+  text: string;
+  value: string;
+  align?: "start" | "center" | "end"
+}>`;
+  const itemType = '{ [key: string]: string | number }';
+  const itemsType = `Array<${itemType}>`;
+</script>
+
+# Table
+
+Simple data table.
+
+<Showcase>
+  <div slot="showcase" class="padded">
+    <Table {headers} {items} />
+  </div>
+  <div slot="source">
+
+```svelte
+<script>
+const headers = [
+  { text: 'First Name', value: 'firstName' },
+  { text: 'Last Name', value: 'lastName' },
+  { text: 'Age', value: 'age', align: 'end' },
+];
+const items = [
+  { firstName: 'John', lastName: 'Doe', age: 694 },
+  { firstName: 'Leo', lastName: 'Tolstoy', age: new Date().getFullYear() - 1828 },
+  { firstName: 'فلان', lastName: 'الفلاني', age: 42 },
+  { firstName: 'Иван', lastName: 'Иванов', age: 69 },
+]
+</script>
+
+<Table {headers} {items} />
+```
+
+  </div>
+</Showcase>
+
+
+## Properties {#properties}
+
+### Style Properties
+
+| Name | Default | Type | Description |
+| ---- | ------- | ---- | ----------- |
+| **`alternatingRows`** | `true` | `boolean` | Controls whether rows will have an alternating background color. |
+
+### Functional Properties
+
+| Name | Default | Type | Description |
+| ---- | ------- | ---- | ----------- |
+| **`headers`** | `[]` | <code>{headersType}</code> | The header row of the table. |
+| **`items`** | `[]` | <code>{itemsType}</code> | The actual rows of data to be displayed. It is an array of objects, where each object must have as its keys the content of the `value` property of the headers, and the value is the text to be displayed. |
+| **`...`** |  | `any` | Everything else will be passed to the underlying `<table>` element. |
+
+## Slots {#slots}
+
+### Default slot
+
+The full content of the table. Providing this slot defeats the purpose of the component, but it can be useful if you want to make use of the same styles with highly customized content.
+Other -more refined- slots are also available for more convenience.
+
+### `header` slot
+
+The header row that defaults to a `<thead>` element with the row of headers.
+
+### `body` slot
+
+The entire body of the table that defaults to a `<tbody>` element.
+
+### `row` slot
+
+Customizes the entire row of data that defaults to a `<tr>` element.
+
+| Prop Name | Type | Description |
+| --------- | ---- | ----------- |
+| **`item`** | <code>{itemType}</code> | The row object passed as part of the `items` array. |
+
+### `item` slot
+
+Used to customize each data cell on its own. This will probably be the most useful slot.
+The intersection of `header` and `item` can be used to identify the data cell.
+
+| Prop Name | Type | Description |
+| --------- | ---- | ----------- |
+| **`header`** | <code>{headerType}</code> | The header object passed as part of the `headers` array. |
+| **`item`** | <code>{itemType}</code> | The row object passed as part of the `items` array. |
+
+## SCSS Variables {#scss-variables}
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| **`$main`** | Used for the border color and the background color of alternating rows. | <ColorPreview value="#4300B0" /> |
+| **`$table-radius`** | The border radius of the table body. | `0.5em` |

--- a/docs/src/routes/docs/components/table.svx
+++ b/docs/src/routes/docs/components/table.svx
@@ -40,17 +40,17 @@ Simple data table.
 
 ```svelte
 <script>
-const headers = [
-  { text: 'First Name', value: 'firstName' },
-  { text: 'Last Name', value: 'lastName' },
-  { text: 'Age', value: 'age', align: 'end' },
-];
-const items = [
-  { firstName: 'John', lastName: 'Doe', age: 694 },
-  { firstName: 'Leo', lastName: 'Tolstoy', age: new Date().getFullYear() - 1828 },
-  { firstName: 'فلان', lastName: 'الفلاني', age: 42 },
-  { firstName: 'Иван', lastName: 'Иванов', age: 69 },
-]
+  const headers = [
+    { text: 'First Name', value: 'firstName' },
+    { text: 'Last Name', value: 'lastName' },
+    { text: 'Age', value: 'age', align: 'end' },
+  ];
+  const items = [
+    { firstName: 'John', lastName: 'Doe', age: 694 },
+    { firstName: 'Leo', lastName: 'Tolstoy', age: new Date().getFullYear() - 1828 },
+    { firstName: 'فلان', lastName: 'الفلاني', age: 42 },
+    { firstName: 'Иван', lastName: 'Иванов', age: 69 },
+  ];
 </script>
 
 <Table {headers} {items} />


### PR DESCRIPTION
The component was directly taken from the docs, with a few added props and slots.

I am also thinking that:
1- slots should be inside the `th`/`tr`/`td`, not replace them (to preserve proper semantics and avoid mistakes by forgetting to add the wrapping element)
2- the `header` slot should be like the `item` one in that it replaces just one header (which it takes as a prop) and not the entire row. Or should we make both slots?

And I feel that the wording in the docs can be improved a bit.

Closes #255