### PR TITLE
Add `--no-git-checks` to `pnpm publish`

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -89,6 +89,6 @@ jobs:
 
       - name: Release 🚀
         working-directory: attractions
-        run: pnpm publish
+        run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
It was breaking releases due to the copying of README and LICENSE files