### PR TITLE
`closeOnClick` prop for the `DatePicker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Added
 
 - The [`Slider`](https://illright.github.io/attractions/docs/components/slider) component has been added, allowing you to create a slider similar to the one you would get with `<input type="range">`. It also support inputting a range by supplying a tuple for the `value` prop (Thanks to [@RikuVan](https://github.com/RikuVan) for the contribution - [#290](https://github.com/illright/attractions/pull/290)).
-- The `closeOnClick` prop to the `DatePicker` component has been added.
+- The `closeOnSelection` prop to the `DatePicker` component has been added.
 
 ### Changed
 

--- a/attractions/date-picker/date-picker.svelte
+++ b/attractions/date-picker/date-picker.svelte
@@ -90,7 +90,7 @@
    * If `true`, the dropdown will be automatically closed after a date is selected.
    * @type {boolean}
    */
-  export let closeOnClick = false;
+  export let closeOnSelection = false;
   /**
    * The format string for the text input and representation. The `%`-specifiers are a subset of [C date format specifiers](http://www.cplusplus.com/reference/ctime/strftime/), with only `%d`, `%m`, `%y` and `%Y` allowed.
    * @type {string}
@@ -141,7 +141,11 @@
       }
     }
 
-    if (closeOnClick && startValue != null && (!range || endValue != null)) {
+    if (
+      closeOnSelection &&
+      startValue != null &&
+      (!range || endValue != null)
+    ) {
       startFocus = endFocus = false;
     }
 

--- a/docs/src/routes/docs/components/date-picker.svx
+++ b/docs/src/routes/docs/components/date-picker.svx
@@ -30,14 +30,14 @@ If you need to display the calendar differently, check out the [`Calendar`](./do
 
 <Showcase>
   <div slot="showcase" class="padded">
-    <DatePicker format="%m/%d/%Y" closeOnClick />
+    <DatePicker format="%m/%d/%Y" closeOnSelection />
     <DatePicker format="%m/%d" noCalendar />
     <DatePicker range top />
   </div>
   <div slot="source">
 
 ```svelte
-<DatePicker format="%m/%d/%Y" closeOnClick />
+<DatePicker format="%m/%d/%Y" closeOnSelection />
 <DatePicker format="%m/%d" noCalendar />
 <DatePicker range top />
 ```
@@ -65,7 +65,7 @@ If you need to display the calendar differently, check out the [`Calendar`](./do
 | **`locale`** | `undefined` | `string` | The language tag defining the desired locale (e.g., `en-US`). If left `undefined`, the user's locale will be used. <br /> This will affect the weekdays and the day number representations as well as the spelling of the selected month.  |
 | **`firstWeekday`** | `1` | `number` | The index of the weekday to start the week at. <br /> 0 is for Sunday and 6 is for Saturday. |
 | **`disabledDates`** | `[]` | <code>{disabledDatesType}</code> | A range of dates (or date ranges) for which to disable selection. |
-| **`closeOnClick`** | `false` | `boolean` | If `true`, the dropdown will be automatically closed after a date is selected. |
+| **`closeOnSelection`** | `false` | `boolean` | If `true`, the dropdown will be automatically closed after a date is selected. |
 | **`format`** | `'%d.%m.%Y'` | `string` | The format string for the text input and representation. The `%`-specifiers are a subset of [C date format specifiers](http://www.cplusplus.com/reference/ctime/strftime/), with only `%d`, `%m`, `%y` and `%Y` allowed. |
 
 ### Class Properties


### PR DESCRIPTION
I implemented it like in the referenced issue, but I feel like `closeOnSelected` would be a more appropriate name (especially to account for the `range` date picker). What do you think?

Resolves #307