### PR TITLE
Fix Bundlephobia `BuildError`

### DIFF
--- a/attractions/checkbox/checkbox-group.svelte
+++ b/attractions/checkbox/checkbox-group.svelte
@@ -59,6 +59,7 @@
    */
   export let maxReachedTooltip = null;
   $: maxReachedTooltipFinal =
+    // TODO: switch back to `??` after https://github.com/pastelsky/bundlephobia/issues/530 is merged
     maxReachedTooltip || `Can only select ${max} value${s(max)}.`;
 
   $: currentChecked = items.reduce((acc, elt) => acc + elt.checked, 0);

--- a/attractions/chip/checkbox-chip-group.svelte
+++ b/attractions/chip/checkbox-chip-group.svelte
@@ -44,6 +44,7 @@
    */
   export let maxReachedTooltip = null;
   $: maxReachedTooltipFinal =
+    // TODO: switch back to `??` after https://github.com/pastelsky/bundlephobia/issues/530 is merged
     maxReachedTooltip || `Can only select ${max} value${s(max)}.`;
 
   $: currentChecked = items.reduce((acc, elt) => acc + elt.checked, 0);


### PR DESCRIPTION
By replacing `??` with `||`, as Bundlephobia does not yet support "modern" JS syntax.