### PR TITLE
Change from absolute color to scss varaible

### DIFF
--- a/attractions/card/card.scss
+++ b/attractions/card/card.scss
@@ -2,7 +2,7 @@
 @use 'node_modules/attractions/_variables' as vars;
 
 .card {
-  background-color: #fff;
+  background-color: vars.$background;
   border-radius: vars.$card-radius;
   box-shadow: vars.$shadow-0;
   overflow: hidden;


### PR DESCRIPTION
Minor fix to adapt `card`'s background to use the theme background variable instead of using an absolute value.