### PR TITLE
Hotfix: sveld-generated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.5.1] - 2021-11-20
+
+### Fixed
+
+- Fixed a minor regression in the types of components that extend other components ([#325](https://github.com/illright/attractions/issues/325)).
+
 ## [3.5.0] - 2021-11-08
 
 ### Added

--- a/attractions/autocomplete/autocomplete-field.svelte
+++ b/attractions/autocomplete/autocomplete-field.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @typedef {typeof import('./autocomplete-option.svelte').Option} Option
+   * @typedef {import('./autocomplete-option.svelte').Option} Option
    * @typedef {(q: string) => Generator<Promise<Option[]>, never, never>} OptionsGetter
    * @slot {{ loadMoreOptions: (click?: CustomEvent<{ nativeEvent: MouseEvent }>) => void }} more-options
    * @event {{ value: Option[] }} change

--- a/attractions/autocomplete/autocomplete-field.svelte
+++ b/attractions/autocomplete/autocomplete-field.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * @typedef {typeof import('./autocomplete-option').Option} Option
+   * @typedef {typeof import('./autocomplete-option.svelte').Option} Option
    * @typedef {(q: string) => Generator<Promise<Option[]>, never, never>} OptionsGetter
    * @slot {{ loadMoreOptions: (click?: CustomEvent<{ nativeEvent: MouseEvent }>) => void }} more-options
    * @event {{ value: Option[] }} change

--- a/attractions/autocomplete/autocomplete.svelte
+++ b/attractions/autocomplete/autocomplete.svelte
@@ -1,13 +1,13 @@
 <script>
   /**
    * @typedef {import('./autocomplete-field').OptionsGetter} OptionsGetter
-   * @typedef {import('./autocomplete-option').Option} Option
+   * @typedef {import('./autocomplete-option.svelte').Option} Option
    * @slot {{ }} loading-options
    * @slot {{ loadMoreOptions: (click?: CustomEvent<{ nativeEvent: MouseEvent }>) => void }} more-options
    * @slot {{ }} not-enough-input
    * @slot {{ }} too-many-options
    * @event {{ value: Option[] }} change
-   * @extends {'./autocomplete-field'} AutocompleteFieldProps
+   * @extends {'./autocomplete-field.svelte'} AutocompleteFieldProps
    */
   import { createEventDispatcher } from 'svelte';
   import Button from '../button/button.svelte';

--- a/attractions/autocomplete/autocomplete.svelte
+++ b/attractions/autocomplete/autocomplete.svelte
@@ -1,6 +1,5 @@
 <script>
   /**
-   * @typedef {import('./autocomplete-field').OptionsGetter} OptionsGetter
    * @typedef {import('./autocomplete-option.svelte').Option} Option
    * @slot {{ }} loading-options
    * @slot {{ loadMoreOptions: (click?: CustomEvent<{ nativeEvent: MouseEvent }>) => void }} more-options

--- a/attractions/checkbox/checkbox-group.svelte
+++ b/attractions/checkbox/checkbox-group.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @event {{ value: string; checked: boolean; nativeEvent: Event }} change
-   * @extends {'./checkbox'} CheckboxProps
+   * @extends {'./checkbox.svelte'} CheckboxProps
    */
   import classes from '../utils/classes.js';
   import getColorPickerStyles from '../utils/color-picker-styles.js';

--- a/attractions/chip/checkbox-chip-group.svelte
+++ b/attractions/chip/checkbox-chip-group.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @event {{ value: string; checked: boolean; nativeEvent: Event }} change
-   * @extends {'./checkbox-chip'} CheckboxChipProps
+   * @extends {'./checkbox-chip.svelte'} CheckboxChipProps
    */
   import s from '../utils/plural-s.js';
   import classes from '../utils/classes.js';

--- a/attractions/chip/radio-chip-group.svelte
+++ b/attractions/chip/radio-chip-group.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @event {{ value: string; nativeEvent: Event }} change
-   * @extends {'./radio-chip'} RadioChipProps
+   * @extends {'./radio-chip.svelte'} RadioChipProps
    */
   import classes from '../utils/classes.js';
   import RadioChip from './radio-chip.svelte';

--- a/attractions/package.json
+++ b/attractions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attractions",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "A UI kit for Svelte",
   "homepage": "https://illright.github.io/attractions/",
   "bugs": "https://github.com/illright/attractions/issues",

--- a/attractions/radio-button/radio-group.svelte
+++ b/attractions/radio-button/radio-group.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @event {{ value: string; nativeEvent: Event }} change
-   * @extends {'./radio-button'} RadioButtonProps
+   * @extends {'./radio-button.svelte'} RadioButtonProps
    */
   import classes from '../utils/classes.js';
   import getColorPickerStyles from '../utils/color-picker-styles.js';

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-node-resolve": "^13.0.6",
     "@rollup/plugin-replace": "^3.0.0",
-    "attractions": "workspace:^3.5.0",
+    "attractions": "workspace:^3.5.1",
     "eslint-config-prettier": "^8.3.0",
     "mdsvex": "^0.9.8",
     "postcss": "^8.3.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
       '@rollup/plugin-commonjs': ^20.0.0
       '@rollup/plugin-node-resolve': ^13.0.6
       '@rollup/plugin-replace': ^3.0.0
-      attractions: workspace:^3.5.0
+      attractions: workspace:^3.5.1
       clipboard-polyfill: ^3.0.3
       compression: ^1.7.4
       eslint-config-prettier: ^8.3.0
@@ -136,7 +136,7 @@ importers:
       '@rollup/plugin-node-resolve': 13.0.6_rollup@2.59.0
       '@rollup/plugin-replace': 3.0.0_rollup@2.59.0
       attractions: link:../attractions
-      eslint-config-prettier: 8.3.0_eslint@7.32.0
+      eslint-config-prettier: 8.3.0_eslint@8.2.0
       mdsvex: 0.9.8_svelte@3.44.1
       postcss: 8.3.11
       prettier: 2.4.0
@@ -2643,15 +2643,6 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-    dev: true
-
-  /eslint-config-prettier/8.3.0_eslint@7.32.0:
-    resolution: {integrity: sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      eslint: 7.32.0
     dev: true
 
   /eslint-config-prettier/8.3.0_eslint@8.2.0:


### PR DESCRIPTION
Update component `@extends` annotations and relative type imports to add the `.svelte` extension to align with the changes in [sveld v0.10.0](https://github.com/carbon-design-system/sveld/blob/main/CHANGELOG.md#0100---2021-08-28).

Fixes #325 