### PR TITLE
Add slots for translation

### DIFF
--- a/attractions/autocomplete/autocomplete-field.svelte
+++ b/attractions/autocomplete/autocomplete-field.svelte
@@ -191,7 +191,9 @@
               >
                 <Button on:click={loadMoreOptions}>
                   <MoreHorizontal />
-                  <slot name="load-more-options-message">load more options</slot>
+                  <slot name="load-more-options-message">
+                    load more options
+                  </slot>
                 </Button>
               </li>
             </slot>

--- a/attractions/autocomplete/autocomplete-field.svelte
+++ b/attractions/autocomplete/autocomplete-field.svelte
@@ -140,7 +140,7 @@
   <Dropdown>
     <div class="shown-on-focus">
       <Button noRipple on:click={() => (focus = false)}>
-        close the options
+        <slot name="close-message">close the options</slot>
       </Button>
     </div>
     {#if selection.length >= maxOptions}
@@ -167,7 +167,7 @@
             <slot name="loading-options">
               <li class="loading-options">
                 <Loading />
-                Loading...
+                <slot name="loading-message">Loading...</slot>
               </li>
             </slot>
           {:then options}
@@ -191,7 +191,7 @@
               >
                 <Button on:click={loadMoreOptions}>
                   <MoreHorizontal />
-                  load more options
+                  <slot name="load-more-options-message">load more options</slot>
                 </Button>
               </li>
             </slot>

--- a/attractions/autocomplete/autocomplete.svelte
+++ b/attractions/autocomplete/autocomplete.svelte
@@ -98,7 +98,7 @@
     <slot name="loading-options" slot="loading-options">
       <li class="loading-options">
         <Loading />
-        Loading...
+        <slot name="loading-message">Loading...</slot>
       </li>
     </slot>
     <li class="more-options" slot="more-options" let:loadMoreOptions>
@@ -106,7 +106,7 @@
         <div use:callOnSight={{ callback: loadMoreOptions }}>
           <Button on:click={loadMoreOptions}>
             <MoreHorizontal />
-            load more options
+            <slot name="load-more-options-message">load more options</slot>
           </Button>
         </div>
       </slot>

--- a/attractions/date-picker/calendar.svelte
+++ b/attractions/date-picker/calendar.svelte
@@ -67,6 +67,18 @@
    * @type {Array<Date | { start?: Date; end?: Date }>}
    */
   export let disabledDates = [];
+  /**
+   * Messages translation for "today not available".
+   */
+  export let titleTodayNotAvailableMessage = 'Today, not available';
+  /**
+   * Messages translation for "today".
+   */
+  export let titleTodayMessage = 'Today';
+  /**
+   * Messages translation for "not available".
+   */
+  export let titleNotAvailableMessage = 'Not available';
 
   const weekdays = getWeekdays(locale, firstWeekday);
   const today = new Date();
@@ -74,14 +86,14 @@
   function computeTitle(day) {
     if (datesEqual(day.value, today)) {
       if (day.disabled) {
-        return 'Today, not available';
+        return titleTodayNotAvailableMessage;
       } else {
-        return 'Today';
+        return titleTodayMessage;
       }
     }
 
     if (day.disabled) {
-      return 'Not available';
+      return titleNotAvailableMessage;
     }
 
     return null;

--- a/attractions/file-input/file-dropzone.svelte
+++ b/attractions/file-input/file-dropzone.svelte
@@ -131,7 +131,9 @@
         {:else if dragActive}
           <slot name="release-to-upload-message">release to upload</slot>
         {:else}
-          <slot name="drag-and-drop-message">drag &amp; drop here or click to upload files</slot>
+          <slot name="drag-and-drop-message">
+            drag &amp; drop here or click to upload files
+          </slot>
         {/if}
       </div>
     </slot>

--- a/attractions/file-input/file-dropzone.svelte
+++ b/attractions/file-input/file-dropzone.svelte
@@ -125,12 +125,14 @@
       <Paperclip class="icon" />
       <div class="title">
         {#if disabled}
-          file upload unavailable
+          <slot name="upload-unavailable-message">file upload unavailable</slot>
         {:else if wrongType}
-          incorrect file type
+          <slot name="incorrect-file-message">incorrect file type</slot>
         {:else if dragActive}
-          release to upload
-        {:else}drag &amp; drop here or click to upload files{/if}
+          <slot name="release-to-upload-message">release to upload</slot>
+        {:else}
+          <slot name="drag-and-drop-message">drag &amp; drop here or click to upload files</slot>
+        {/if}
       </div>
     </slot>
   </div>

--- a/attractions/file-input/file-input.svelte
+++ b/attractions/file-input/file-input.svelte
@@ -68,11 +68,11 @@
       {...$$restProps}
       on:change={e => dispatch('change', { value, nativeEvent: e })}
     />
-    <slot>
+    <slot name="select-file-message">
       {#if multiple}
-        <slot name="select-files-message">select files</slot>
+        select files
       {:else}
-        <slot name="select-one-file-message">select a file</slot>
+        select a file
       {/if}
     </slot>
   </label>

--- a/attractions/file-input/file-input.svelte
+++ b/attractions/file-input/file-input.svelte
@@ -68,7 +68,13 @@
       {...$$restProps}
       on:change={e => dispatch('change', { value, nativeEvent: e })}
     />
-    <slot>{multiple ? 'select files' : 'select a file'}</slot>
+    <slot>
+      {#if multiple}
+        <slot name="select-files-message">select files</slot>
+      {:else}
+        <slot name="select-one-file-message">select a file</slot>
+      {/if}
+    </slot>
   </label>
   {#if value != null && value.length !== 0}
     <Button danger on:click={clearSelection}>clear selection</Button>

--- a/attractions/form-field/form-field.svelte
+++ b/attractions/form-field/form-field.svelte
@@ -69,9 +69,13 @@
       {/if}
     {/each}
     {#if required}
-      <div class="message info">* Required</div>
+      <div class="message info">
+        <slot name="required-message">* Required</slot>
+      </div>
     {:else if optional}
-      <div class="message info">Optional</div>
+      <div class="message info">
+        <slot name="optional-message">Optional</slot>
+      </div> 
     {/if}
     <slot name="message" />
   </div>

--- a/attractions/form-field/form-field.svelte
+++ b/attractions/form-field/form-field.svelte
@@ -75,7 +75,7 @@
     {:else if optional}
       <div class="message info">
         <slot name="optional-message">Optional</slot>
-      </div> 
+      </div>
     {/if}
     <slot name="message" />
   </div>

--- a/docs/src/routes/docs/components/autocomplete-field.svx
+++ b/docs/src/routes/docs/components/autocomplete-field.svx
@@ -120,6 +120,10 @@ The loading state of the dropdown while the next promise with suggestions is res
 The element to display at the end of a list to trigger the option generator.
 Defaults to a button equipped with an `IntersectionObserver` to trigger the generator whenever it scrolls into view.
 
+| Prop Name | Type | Description |
+| --------- | ---- | ----------- |
+| **`loadMoreOptions`** | `Function` | A callback to trigger the option generator. |
+
 ### `close-message` slot
 
 Use this slot to translate the "close the options" message that appears when tabbing into the dropdown of options.
@@ -131,10 +135,6 @@ Use this slot to translate the "loading" message that appears while the options 
 ### `load-more-options-message` slot
 
 Use this slot to translate the "load more options" message that appears when you scroll to the bottom of the list of options before the infinite scroll triggers loading itself.
-
-| Prop Name | Type | Description |
-| --------- | ---- | ----------- |
-| **`loadMoreOptions`** | `Function` | A callback to trigger the option generator. |
 
 
 ## SCSS Variables {#scss-variables}

--- a/docs/src/routes/docs/components/autocomplete-field.svx
+++ b/docs/src/routes/docs/components/autocomplete-field.svx
@@ -122,15 +122,15 @@ Defaults to a button equipped with an `IntersectionObserver` to trigger the gene
 
 ### `close-message` slot
 
-For translate the "close" message.
+Use this slot to translate the "close the options" message that appears when tabbing into the dropdown of options.
 
 ### `loading-message` slot
 
-For translate the "loading" message.
+Use this slot to translate the "loading" message that appears when the options are loading.
 
 ### `load-more-options-message` slot
 
-For translate the "load more option" message.
+Use this slot to translate the "load more options" message.
 
 | Prop Name | Type | Description |
 | --------- | ---- | ----------- |

--- a/docs/src/routes/docs/components/autocomplete-field.svx
+++ b/docs/src/routes/docs/components/autocomplete-field.svx
@@ -120,6 +120,18 @@ The loading state of the dropdown while the next promise with suggestions is res
 The element to display at the end of a list to trigger the option generator.
 Defaults to a button equipped with an `IntersectionObserver` to trigger the generator whenever it scrolls into view.
 
+### `close-message` slot
+
+For translate the "close" message.
+
+### `loading-message` slot
+
+For translate the "loading" message.
+
+### `load-more-options-message` slot
+
+For translate the "load more option" message.
+
 | Prop Name | Type | Description |
 | --------- | ---- | ----------- |
 | **`loadMoreOptions`** | `Function` | A callback to trigger the option generator. |

--- a/docs/src/routes/docs/components/autocomplete-field.svx
+++ b/docs/src/routes/docs/components/autocomplete-field.svx
@@ -126,11 +126,11 @@ Use this slot to translate the "close the options" message that appears when tab
 
 ### `loading-message` slot
 
-Use this slot to translate the "loading" message that appears when the options are loading.
+Use this slot to translate the "loading" message that appears while the options are loading.
 
 ### `load-more-options-message` slot
 
-Use this slot to translate the "load more options" message.
+Use this slot to translate the "load more options" message that appears when you scroll to the bottom of the list of options before the infinite scroll triggers loading itself.
 
 | Prop Name | Type | Description |
 | --------- | ---- | ----------- |

--- a/docs/src/routes/docs/components/calendar.svx
+++ b/docs/src/routes/docs/components/calendar.svx
@@ -38,7 +38,7 @@ If you're seeking a ready-to-use date picking solution, consider using [`DatePic
 </Showcase>
 
 
-## Properties {#properties}
+## Properties {#properties} 
 
 ### Functional Properties
 
@@ -63,6 +63,14 @@ Falsy values passed to classes will be disregarded.
 | **`weekdaysClass`** | `null` | `string` | A class string to add to the list of weekdays above the calendar. |
 | **`weekClass`** | `null` | `string` | A class string to add to the element containing each row of days in the calendar. |
 | **`dayClass`** | `null` | `string` | A class string to add to each day in the calendar. |
+
+### Translation Properties
+
+| Name | Default | Type | Description |
+| ---- | ------- | ---- | ----------- |
+| **titleTodayNotAvailableMessage** | `Today, not available` | `string` | Translation for title message |
+| **titleTodayMessage** | `Today` | `string` | Translation for title message |
+| **titleNotAvailableMessage** | `Not available` | `string` | Translation for title message |
 
 
 ## Events {#events}

--- a/docs/src/routes/docs/components/calendar.svx
+++ b/docs/src/routes/docs/components/calendar.svx
@@ -68,7 +68,7 @@ Falsy values passed to classes will be disregarded.
 
 | Name | Default | Type | Description |
 | ---- | ------- | ---- | ----------- |
-| **titleTodayNotAvailableMessage** | `Today, not available` | `string` | Translation for title message |
+| **titleTodayNotAvailableMessage** | `Today, not available` | `string` | The tooltip text that appears when hovering over the current day when it is disabled. |
 | **titleTodayMessage** | `Today` | `string` | Translation for title message |
 | **titleNotAvailableMessage** | `Not available` | `string` | Translation for title message |
 

--- a/docs/src/routes/docs/components/calendar.svx
+++ b/docs/src/routes/docs/components/calendar.svx
@@ -38,7 +38,7 @@ If you're seeking a ready-to-use date picking solution, consider using [`DatePic
 </Showcase>
 
 
-## Properties {#properties} 
+## Properties {#properties}
 
 ### Functional Properties
 
@@ -68,9 +68,9 @@ Falsy values passed to classes will be disregarded.
 
 | Name | Default | Type | Description |
 | ---- | ------- | ---- | ----------- |
-| **titleTodayNotAvailableMessage** | `Today, not available` | `string` | The tooltip text that appears when hovering over the current day when it is disabled. |
-| **titleTodayMessage** | `Today` | `string` | Translation for title message |
-| **titleNotAvailableMessage** | `Not available` | `string` | Translation for title message |
+| **titleTodayNotAvailableMessage** | `"Today, not available"` | `string` | The tooltip text that appears when hovering over the current day when it is disabled. |
+| **titleTodayMessage** | `"Today"` | `string` | The tooltip text that appears when hovering over the current day. |
+| **titleNotAvailableMessage** | `"Not available"` | `string` | The tooltip text that appears when hovering over a day that is disabled. |
 
 
 ## Events {#events}

--- a/docs/src/routes/docs/components/file-dropzone.svx
+++ b/docs/src/routes/docs/components/file-dropzone.svx
@@ -90,6 +90,22 @@ The inner content of the dropzone when no files are selected. Defaults to a mess
 
 The plus icon inside the dropzone when there are files inside. <mark>Bonus</mark>: if supplied with a `plus` class, rotates 45 degrees to become an X when an incorrect file is uploaded. Defaults to [Feather icons](https://feathericons.com/?query=plus)' `Plus`.
 
+### `upload-unavailable-message` slot
+
+For translate the "upload unvailable" message.
+
+### `incorrect-file-message` slot
+
+For translate the "incorrect file" message.
+
+### `release-to-upload-message` slot
+
+For translate the "release to upload" message.
+
+### `drag-and-drop-message` slot
+
+For translate the "drag and drop" message.
+
 
 ## SCSS Variables {#scss-variables}
 

--- a/docs/src/routes/docs/components/file-dropzone.svx
+++ b/docs/src/routes/docs/components/file-dropzone.svx
@@ -92,19 +92,19 @@ The plus icon inside the dropzone when there are files inside. <mark>Bonus</mark
 
 ### `upload-unavailable-message` slot
 
-For translate the "upload unvailable" message.
+The text to display when the dropzone is disabled. Defaults to "`upload unavailable`".
 
 ### `incorrect-file-message` slot
 
-For translate the "incorrect file" message.
+The text to display when the file being dropped is of an incorrect type. Defaults to "`incorrect file type`".
 
 ### `release-to-upload-message` slot
 
-For translate the "release to upload" message.
+The text to display when a file is of the correct file is dragged over the dropzone. Defaults to "`release to upload`".
 
 ### `drag-and-drop-message` slot
 
-For translate the "drag and drop" message.
+The default message to display when the dropzone is enabled but nothing is being dragged over it. Defaults to "`drag & drop here or click to upload files`".
 
 
 ## SCSS Variables {#scss-variables}

--- a/docs/src/routes/docs/components/file-input.svx
+++ b/docs/src/routes/docs/components/file-input.svx
@@ -87,6 +87,14 @@ Falsy values passed to classes will be disregarded.
 
 ## Slots {#slots}
 
+### `select-files-message` slot
+
+For translate the "select file" message.
+
+### `select-one-file-message` slot
+
+For translate the "select one file" message.
+
 ### Default slot
 
 The label of the main upload button. Defaults to the text "select a file" / "select files" depending on the value of the <mark>`multiple`</mark> property.

--- a/docs/src/routes/docs/components/file-input.svx
+++ b/docs/src/routes/docs/components/file-input.svx
@@ -87,13 +87,9 @@ Falsy values passed to classes will be disregarded.
 
 ## Slots {#slots}
 
-### `select-files-message` slot
+### `select-file-message` slot
 
-For translate the "select file" message.
-
-### `select-one-file-message` slot
-
-For translate the "select one file" message.
+Use this slot to translate the "select file" message that appears when tabbing into the dropdown of options.
 
 ### Default slot
 

--- a/docs/src/routes/docs/components/form-field.svx
+++ b/docs/src/routes/docs/components/form-field.svx
@@ -111,6 +111,14 @@ Additional content to put in the form field description block, after the name an
 
 Additional text to put underneath the actual field along with the messages like "required", "optional" and errors.
 
+### `required-message` slot
+
+For translate the "required" message.
+
+### `optional-message` slot
+
+For translate the "optional" message.
+
 
 ## SCSS Variables {#scss-variables}
 

--- a/docs/src/routes/docs/components/form-field.svx
+++ b/docs/src/routes/docs/components/form-field.svx
@@ -113,11 +113,11 @@ Additional text to put underneath the actual field along with the messages like 
 
 ### `required-message` slot
 
-For translate the "required" message.
+Text to display under the field when it is marked as required. Defaults to "`* Required`".
 
 ### `optional-message` slot
 
-For translate the "optional" message.
+Text to display under the field when it is marked as optional. Defaults to "`Optional`".
 
 
 ## SCSS Variables {#scss-variables}


### PR DESCRIPTION
This issue allows to add slots to be able to translate the messages of the components. 

Close #315 

## Slots
- [x] `AutocompleteField`:
  - Line 142: "close the options": `close-message`
  - Line 169: "Loading": `loading-message`
  - Line 193: "load more options": `load-more-options-message`
- [x] `Autocomplete`:
  - Line 101: "Loading": `loading-message`
  - Line 193: "load more options": `load-more-options-message`
- [x] `Calendar`:
  - Line 77: "Today, not available": `titleTodayNotAvailableMessage` (props)
  - Line 79: "Today": `titleTodayMessage` (props)
  - Line 84: "Not available": `titleTodayMessage` (props)
- [x] `FileDropzone`: 
  - Line 128: "file upload unavailable": `upload-unavailable-message`
  - Line 130: "incorrect file type": `incorrect-file-message`
  - Line 132: "release to upload": `release-to-upload-message`
  - Line 134: "drag &amp; drop here or click to upload files": `drag-and-drop-message`
- [x] `FileInput`: 
  - Line 73: "select files": `select-files-message`
  - Line 75: "select a file": `select-one-file-message`
- [x] `FormField`:
  - Line 71: "Required": `required-message`
  - Line 73: "Optional": `optinal-message`