### PR TITLE
Swap button attribute disabled to aria-disabled

### DIFF
--- a/attractions/button/button.svelte
+++ b/attractions/button/button.svelte
@@ -125,7 +125,7 @@
 {:else}
   <button
     type="button"
-    {disabled}
+    aria-disabled={disabled}
     class={classes('btn', _class)}
     class:filled
     class:outline


### PR DESCRIPTION
As the title suggests, I have swapped the current `disabled` attribute to the `aria-disabled` on the button as that makes the component more inclusive for users with assistive technologies.
