### PR TITLE
Prevent svelte compiler from throwing accessibility warnings where we only care about the click event

### DIFF
--- a/attractions/autocomplete/autocomplete-option.svelte
+++ b/attractions/autocomplete/autocomplete-option.svelte
@@ -33,6 +33,7 @@
   const dispatch = createEventDispatcher();
 </script>
 
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <li on:click|stopPropagation={e => dispatch('click', { nativeEvent: e })}>
   <button type="button">
     {#each markMatch(option.name) as part}

--- a/attractions/file-input/file-dropzone.svelte
+++ b/attractions/file-input/file-dropzone.svelte
@@ -104,6 +104,7 @@
   const dispatch = createEventDispatcher();
 </script>
 
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <label
   class={classes('file-dropzone', _class)}
   class:has-content={files && files.length !== 0}

--- a/attractions/modal/modal.svelte
+++ b/attractions/modal/modal.svelte
@@ -29,6 +29,7 @@
 </script>
 
 {#if !noClickaway}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
   <div
     class:open
     on:click|self={close}


### PR DESCRIPTION
Svelte compiler complains about non-interactive elements with on:click handlers not having a keyboard alternative  for a11y purposes.

This change adds missing event handlers.